### PR TITLE
Unroll Shrinking Loop

### DIFF
--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -25,9 +25,12 @@ public struct AssertiveQuickCheck {
 			fatalError("Assertive proposition '\(s)' has an undefined test case")
 		}
 		set(test) {
-			switch quickCheckWithResult(stdArgs(name: s), test) {
+			let r = quickCheckWithResult(stdArgs(name: s), test)
+			switch r {
 			case let .Failure(numTests, numShrinks, usedSeed, usedSize, reason, labels, output):
 				XCTFail(reason)
+			case let .NoExpectedFailure(numTests, labels, output):
+				XCTFail("Expected property to fail but it didn't.")
 			default:
 				return
 			}

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -241,8 +241,10 @@ internal func test(st : State, f : (StdGen -> Int -> Prop)) -> Result {
 	while true {
 		switch runATest(state)(f: f) {
 			case let .Left(fail):
-				switch doneTesting(fail.value.1)(f: f) {
-				case let .NoExpectedFailure(numTests, labels, output):
+				switch (fail.value.0, doneTesting(fail.value.1)(f: f)) {
+				case let (.Success(_, _, _), _):
+					return fail.value.0
+				case let (_, .NoExpectedFailure(numTests, labels, output)):
 					return .NoExpectedFailure(numTests: numTests, labels: labels, output: output)
 				default:
 					return fail.value.0

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -446,7 +446,7 @@ internal func localMin(st : State, res : TestResult, res2 : TestResult, ts : [Ro
 
 internal func localMinFound(st : State, res : TestResult) -> (Int, Int, Int) {
 	let testMsg = " (after \(st.numSuccessTests + 1) test"
-	let shrinkMsg = st.numSuccessShrinks > 1 ? ("and \(st.numSuccessShrinks) shrink") : ""
+	let shrinkMsg = st.numSuccessShrinks > 1 ? (" and \(st.numSuccessShrinks) shrink") : ""
 	
 	func pluralize(s : String, i : Int) -> String {
 		if i > 1 {
@@ -456,7 +456,7 @@ internal func localMinFound(st : State, res : TestResult) -> (Int, Int, Int) {
 	}
 	
 	println("Proposition: " + st.name)
-	println(res.reason + pluralize(testMsg, st.numSuccessTests) + pluralize(shrinkMsg, st.numSuccessShrinks) + "):")
+	println(res.reason + pluralize(testMsg, st.numSuccessTests + 1) + pluralize(shrinkMsg, st.numSuccessShrinks) + "):")
 	dispatchAfterFinalFailureCallbacks(st, res)
 	return (st.numSuccessShrinks, st.numTotTryShrinks - st.numTryShrinks, st.numTryShrinks)
 }

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -309,7 +309,7 @@ internal func runATest(st : State)(f : (StdGen -> Int -> Prop)) -> Either<(Resul
 					}
 
 					// Attempt a shrink.
-					let (numShrinks, totFailed, lastFailed) = foundFailure(st, res, ts())
+					let (numShrinks, totFailed, lastFailed) = findMinimalFailingTestCase(st, res, ts())
 
 					if !expect {
 						let s = Result.Success(numTests: st.numSuccessTests + 1, labels: summary(st), output: "+++ OK, failed as expected. ")
@@ -359,7 +359,7 @@ internal func giveUp(st: State)(f : (StdGen -> Int -> Prop)) -> Result {
 // for complex shrinks (much like `split` in the Swift STL), and was slow as hell.  This way we stay
 // in one stack frame no matter what and give ARC a chance to cleanup after us.  Plus we get to
 // stay within a reasonable ~50-100 megabytes for truly horrendous tests that used to eat 8 gigs.
-internal func foundFailure(st : State, res : TestResult, ts : [Rose<TestResult>]) -> (Int, Int, Int) {
+internal func findMinimalFailingTestCase(st : State, res : TestResult, ts : [Rose<TestResult>]) -> (Int, Int, Int) {
 	if let e = res.theException {
 		fatalError("Test failed due to exception: \(e)")
 	}
@@ -424,10 +424,10 @@ internal func foundFailure(st : State, res : TestResult, ts : [Rose<TestResult>]
 					, numSuccessShrinks: numSuccessShrinks
 					, numTryShrinks: numTryShrinks
 					, numTotTryShrinks: numTotTryShrinks)
-	return localMinFound(state, lastResult)
+	return reportMinimumCaseFound(state, lastResult)
 }
 
-internal func localMinFound(st : State, res : TestResult) -> (Int, Int, Int) {
+internal func reportMinimumCaseFound(st : State, res : TestResult) -> (Int, Int, Int) {
 	let testMsg = " (after \(st.numSuccessTests + 1) test"
 	let shrinkMsg = st.numSuccessShrinks > 1 ? (" and \(st.numSuccessShrinks) shrink") : ""
 	

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -350,23 +350,6 @@ internal func giveUp(st: State)(f : (StdGen -> Int -> Prop)) -> Result {
 	return Result.GaveUp(numTests: st.numSuccessTests, labels: summary(st), output: "")
 }
 
-internal func foundFailure(st : State, res : TestResult, ts : [Rose<TestResult>]) -> (Int, Int, Int) {
-	let state = State(name: st.name
-					, maxSuccessTests: st.maxSuccessTests
-					, maxDiscardedTests: st.maxDiscardedTests
-					, computeSize: st.computeSize
-					, numSuccessTests: st.numSuccessTests
-					, numDiscardedTests: st.numDiscardedTests
-					, labels: st.labels
-					, collected: st.collected
-					, expectedFailure: st.expectedFailure
-					, randomSeed: st.randomSeed
-					, numSuccessShrinks: st.numSuccessShrinks
-					, numTryShrinks: st.numTryShrinks + 1
-					, numTotTryShrinks: st.numTotTryShrinks)
-	return localMin(state, res, res, ts)
-}
-
 // Interface to shrinking loop.  Returns (number of shrinks performed, number of failed shrinks, 
 // total number of shrinks performed).
 //
@@ -376,15 +359,15 @@ internal func foundFailure(st : State, res : TestResult, ts : [Rose<TestResult>]
 // for complex shrinks (much like `split` in the Swift STL), and was slow as hell.  This way we stay
 // in one stack frame no matter what and give ARC a chance to cleanup after us.  Plus we get to
 // stay within a reasonable ~50-100 megabytes for truly horrendous tests that used to eat 8 gigs.
-internal func localMin(st : State, res : TestResult, res2 : TestResult, ts : [Rose<TestResult>]) -> (Int, Int, Int) {
-	if let e = res2.theException {
+internal func foundFailure(st : State, res : TestResult, ts : [Rose<TestResult>]) -> (Int, Int, Int) {
+	if let e = res.theException {
 		fatalError("Test failed due to exception: \(e)")
 	}
 
 	var lastResult = res
 	var branches = ts
 	var numSuccessShrinks = st.numSuccessShrinks
-	var numTryShrinks = st.numTryShrinks
+	var numTryShrinks = st.numTryShrinks + 1
 	var numTotTryShrinks = st.numTotTryShrinks
 
 	// cont is a sanity check so we don't fall into an infinite loop.  It is set to false at each

--- a/SwiftCheckTests/ShrinkSpec.swift
+++ b/SwiftCheckTests/ShrinkSpec.swift
@@ -38,11 +38,13 @@ class ShrinkSpec : XCTestCase {
 			}()
 		}
 
-		property["Shrunken sets of integers always contain [] or [0]"] = forAll { (s : SetOf<Int>) in
+		// This should not hold because eventually you'll get to [0, 0] which gets shrunk from
+		// [0] to [[]] which doesn't shrink so you're out of luck.  We'll ExpectFailure here.
+		property["Shrunken sets of integers don't always contain [] or [0]"] = expectFailure(forAll { (s : SetOf<Int>) in
 			return (!s.getSet.isEmpty && s.getSet != Set([0])) ==> {
 				let ls = self.shrinkArbitrary(s).map { $0.getSet }
 				return (ls.filter({ $0 == [] || $0 == [0] }).count >= 1)
 			}()
-		}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #29.

In the process I found a bug in the shrinker that prevented SwiftCheck from reporting the number of shrinks it had just performed.  Strange how being the compiler for a while catches these things...