### PR TITLE
Make Implication Lazy

### DIFF
--- a/SwiftCheck/Operators.swift
+++ b/SwiftCheck/Operators.swift
@@ -13,13 +13,21 @@ infix operator ==> {
 
 /// Models implication for properties.  That is, the property holds if the first argument is false
 /// (in which case the test case is discarded), or if the given property holds.
-public func ==>(b : Bool, p : Testable) -> Property {
+public func ==>(b : Bool, @autoclosure p : () -> Testable) -> Property {
 	if b {
-		return p.property()
+		return p().property()
 	}
 	return Discard().property()
 }
 
+/// Models implication for properties.  That is, the property holds if the first argument is false
+/// (in which case the test case is discarded), or if the given property holds.
+public func ==>(b : Bool, p : () -> Testable) -> Property {
+	if b {
+		return p().property()
+	}
+	return Discard().property()
+}
 
 infix operator ==== {
 	precedence 140

--- a/SwiftCheckTests/ShrinkSpec.swift
+++ b/SwiftCheckTests/ShrinkSpec.swift
@@ -35,7 +35,7 @@ class ShrinkSpec : XCTestCase {
 			return (!l.getArray.isEmpty && l.getArray != [0]) ==> {
 				let ls = self.shrinkArbitrary(l).map { $0.getArray }
 				return (ls.filter({ $0 == [] || $0 == [0] }).count >= 1)
-			}()
+			}
 		}
 
 		// This should not hold because eventually you'll get to [0, 0] which gets shrunk from
@@ -44,7 +44,7 @@ class ShrinkSpec : XCTestCase {
 			return (!s.getSet.isEmpty && s.getSet != Set([0])) ==> {
 				let ls = self.shrinkArbitrary(s).map { $0.getSet }
 				return (ls.filter({ $0 == [] || $0 == [0] }).count >= 1)
-			}()
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes bugs where all postconditions evaluate regardless of the precondition.