### PR TITLE
Debug strings for counterexamples

### DIFF
--- a/SwiftCheck/Operators.swift
+++ b/SwiftCheck/Operators.swift
@@ -35,7 +35,7 @@ infix operator ==== {
 
 /// Like equality but prints a verbose description when it fails.
 public func ====<A where A : Equatable, A : Printable>(x : A, y : A) -> Property {
-	return counterexample(x.description + "/=" + y.description)(p: x == y)
+	return counterexample(toDebugString(x) + "/=" + toDebugString(y))(p: x == y)
 }
 
 

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -107,7 +107,7 @@ public func forAll<A : Arbitrary, B : Arbitrary, C : Arbitrary, D : Arbitrary, E
 public func forAllShrink<A>(gen : Gen<A>, shrinker: A -> [A], f : A -> Testable) -> Property {
 	return Property(gen.bind { x in
 		return shrinking(shrinker, x, { xs  in
-			return counterexample("\(xs)")(p: f(xs))
+			return counterexample(toDebugString(xs))(p: f(xs))
 		}).unProperty
 	})
 }


### PR DESCRIPTION
Counterexamples get printed using `toDebugString`. Thus:

- If the type conforms to `DebugPrintable`, `debugDescription` will be evaluated.
- If the type conforms to `Printable`, `description` will be evaluated (as it was before).
- Otherwise, Swift will construct a default string which will probably not be very helpful.

This allows counterexamples to be printed with more detail than regular descriptions might provide.