### PR TITLE
Timeout

### DIFF
--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -96,7 +96,7 @@ public func once(p : Testable) -> Property {
 	})(p: p)
 }
 
-/// Modifies a property by requiring it to complete before a timeout (in milliseconds).
+/// Modifies a property by requiring it to complete before a timeout (in nanoseconds).
 ///
 /// Long-running operations that do not complete are subject to cancellation any time after the
 /// timeout period.

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -96,7 +96,7 @@ public func once(p : Testable) -> Property {
 	})(p: p)
 }
 
-///
+/// Modifies a property by requiring it to complete before a timeout (in milliseconds).
 public func within(n : Int64, p : Testable) -> Property {
 	return mapRoseResult(withinF(n))(p: p)
 }

--- a/SwiftCheckTests/PropertySpec.swift
+++ b/SwiftCheckTests/PropertySpec.swift
@@ -19,5 +19,10 @@ class PropertySpec : XCTestCase {
 				return b == n
 			})
 		}
+
+		property["within works"] = expectFailure(within(1000, {
+			sleep(1)
+			return true
+		}()))
 	}
 }


### PR DESCRIPTION
Adds `within`.

I want to make this lazy so I can write some ridiculous crap like

```swift
property["Loopz"] = expectFailure(within(1000, {
	while true { }
}))
```

but I need a lazy `Testable` instance first.