### PR TITLE
Relax IsoOf's Constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData
 *.hmap
 *.xcuserstate
 *.xccheckout
+*.xcscmblueprint
 Carthage/Build
 Carthage/Checkouts
 

--- a/SwiftCheck/Modifiers.swift
+++ b/SwiftCheck/Modifiers.swift
@@ -249,7 +249,7 @@ extension ArrowOf : CustomReflectable {
 }
 
 /// Generates two isomorphic Swift function from T to U and back again.
-public struct IsoOf<T : protocol<Hashable, CoArbitrary, Arbitrary>, U : protocol<Hashable, CoArbitrary, Arbitrary>> : Arbitrary, CustomStringConvertible {
+public struct IsoOf<T : protocol<Hashable, CoArbitrary, Arbitrary>, U : protocol<Equatable, CoArbitrary, Arbitrary>> : Arbitrary, CustomStringConvertible {
 	private var table : Dictionary<T, U>
 	private var embed : T -> U
 	private var project : U -> T

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -206,19 +206,19 @@ internal func quickCheckWithResult(args : Arguments, p : Testable) -> Result {
 	
 	
 	let state = CheckerState( name: args.name
-                            , maxSuccessTests:		args.maxSuccess
-                            , maxDiscardedTests:	args.maxDiscard
-                            , computeSize:			computeSize
-                            , numSuccessTests:		0
-                            , numDiscardedTests:	0
-                            , labels:				[:]
-                            , collected:			[]
-                            , expectedFailure:		false
-                            , randomSeed:			rnd()
-                            , numSuccessShrinks:	0
-                            , numTryShrinks:		0
-                            , numTotTryShrinks:		0
-                            , shouldAbort:			false)
+							, maxSuccessTests:		args.maxSuccess
+							, maxDiscardedTests:	args.maxDiscard
+							, computeSize:			computeSize
+							, numSuccessTests:		0
+							, numDiscardedTests:	0
+							, labels:				[:]
+							, collected:			[]
+							, expectedFailure:		false
+							, randomSeed:			rnd()
+							, numSuccessShrinks:	0
+							, numTryShrinks:		0
+							, numTotTryShrinks:		0
+							, shouldAbort:			false)
 	let modP : Property = (p.exhaustive ? p.property.once : p.property)
 	return test(state, f: modP.unProperty.unGen)
 }
@@ -275,36 +275,36 @@ internal func runATest(st : CheckerState)(f : (StdGen -> Int -> Prop)) -> Either
 				// Success
 				case .MatchResult(.Some(true), let expect, _, _, let labels, let stamp, _, let abort):
 					let nstate = CheckerState(name: st.name
-                                            , maxSuccessTests: st.maxSuccessTests
-                                            , maxDiscardedTests: st.maxDiscardedTests
-                                            , computeSize: st.computeSize
-                                            , numSuccessTests: st.numSuccessTests + 1
-                                            , numDiscardedTests: st.numDiscardedTests
-                                            , labels: unionWith(max, l: st.labels, r: labels)
-                                            , collected: [stamp] + st.collected
-                                            , expectedFailure: expect
-                                            , randomSeed: st.randomSeed
-                                            , numSuccessShrinks: st.numSuccessShrinks
-                                            , numTryShrinks: st.numTryShrinks
-                                            , numTotTryShrinks: st.numTotTryShrinks
+											, maxSuccessTests: st.maxSuccessTests
+											, maxDiscardedTests: st.maxDiscardedTests
+											, computeSize: st.computeSize
+											, numSuccessTests: st.numSuccessTests + 1
+											, numDiscardedTests: st.numDiscardedTests
+											, labels: unionWith(max, l: st.labels, r: labels)
+											, collected: [stamp] + st.collected
+											, expectedFailure: expect
+											, randomSeed: st.randomSeed
+											, numSuccessShrinks: st.numSuccessShrinks
+											, numTryShrinks: st.numTryShrinks
+											, numTotTryShrinks: st.numTotTryShrinks
 									, shouldAbort: abort)
 					return .Right(Box(nstate))
 				// Discard
 				case .MatchResult(.None, let expect, _, _, let labels, _, _, let abort):
 					let nstate = CheckerState(name: st.name
-                                            , maxSuccessTests: st.maxSuccessTests
-                                            , maxDiscardedTests: st.maxDiscardedTests
-                                            , computeSize: st.computeSize
-                                            , numSuccessTests: st.numSuccessTests
-                                            , numDiscardedTests: st.numDiscardedTests + 1
-                                            , labels: unionWith(max, l: st.labels, r: labels)
-                                            , collected: st.collected
-                                            , expectedFailure: expect
-                                            , randomSeed: rnd2
-                                            , numSuccessShrinks: st.numSuccessShrinks
-                                            , numTryShrinks: st.numTryShrinks
-                                            , numTotTryShrinks: st.numTotTryShrinks
-                                            , shouldAbort: abort)
+											, maxSuccessTests: st.maxSuccessTests
+											, maxDiscardedTests: st.maxDiscardedTests
+											, computeSize: st.computeSize
+											, numSuccessTests: st.numSuccessTests
+											, numDiscardedTests: st.numDiscardedTests + 1
+											, labels: unionWith(max, l: st.labels, r: labels)
+											, collected: st.collected
+											, expectedFailure: expect
+											, randomSeed: rnd2
+											, numSuccessShrinks: st.numSuccessShrinks
+											, numTryShrinks: st.numTryShrinks
+											, numTotTryShrinks: st.numTotTryShrinks
+											, shouldAbort: abort)
 					return .Right(Box(nstate))
 				// Fail
 				case .MatchResult(.Some(false), let expect, _, _, _, _, _, let abort):

--- a/SwiftCheckTests/ModifierSpec.swift
+++ b/SwiftCheckTests/ModifierSpec.swift
@@ -34,7 +34,7 @@ class ModifierSpec : XCTestCase {
 		property("ArrayOf modifiers nest") <- forAll { (xxxs : ArrayOf<ArrayOf<Int8>>) in
 			return true
 		}
-    
+	
 		property("The reverse of the reverse of an array is that array") <- forAll { (xs : ArrayOf<Int>) in
 			return
 				(xs.getArray.reverse().reverse() == xs.getArray) <?> "Left identity"
@@ -45,13 +45,13 @@ class ModifierSpec : XCTestCase {
 		property("map behaves") <- forAll { (xs : ArrayOf<Int>, f : ArrowOf<Int, Int>) in
 			return xs.getArray.map(f.getArrow) == xs.getArray.map(f.getArrow)
 		}
-        
-        property("IsoOf generates a real isomorphism") <- forAll { (x : Int, y : String, iso : IsoOf<Int, String>) in
-            return
-                iso.getFrom(iso.getTo(x)) == x
-                ^&&^
-                iso.getTo(iso.getFrom(y)) == y
-        }
+		
+		property("IsoOf generates a real isomorphism") <- forAll { (x : Int, y : String, iso : IsoOf<Int, String>) in
+			return
+				iso.getFrom(iso.getTo(x)) == x
+				^&&^
+				iso.getTo(iso.getFrom(y)) == y
+		}
 
 		property("filter behaves") <- forAll { (xs : ArrayOf<Int>, pred : ArrowOf<Int, Bool>) in
 			let f = pred.getArrow


### PR DESCRIPTION
Relaxes the `Hashable` constraint to an `Equatable` one.