### PR TITLE
Add Witnessed Arbitrary Protocol

### DIFF
--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		827749F81B65ABCC00A7965F /* Witness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827749F71B65ABCC00A7965F /* Witness.swift */; };
+		827749F91B65ABCC00A7965F /* Witness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827749F71B65ABCC00A7965F /* Witness.swift */; };
 		82DD8EEC1B4CC88C00B66551 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DD8EEB1B4CC88C00B66551 /* Operators.swift */; };
 		82DD8EED1B4CC88C00B66551 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DD8EEB1B4CC88C00B66551 /* Operators.swift */; };
 		841408BB1B1A85A900BA2B6C /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 84DF75F81B0BD54600C912B0 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -89,6 +91,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		827749F71B65ABCC00A7965F /* Witness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Witness.swift; sourceTree = "<group>"; };
 		82DD8EEB1B4CC88C00B66551 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Carthage/Checkouts/Operadics/Operators.swift; sourceTree = SOURCE_ROOT; };
 		842015101AF5C91C00F1F3CD /* Lattice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lattice.swift; sourceTree = "<group>"; };
 		8445C4A91B16D37800280089 /* GenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenSpec.swift; sourceTree = "<group>"; };
@@ -191,6 +194,7 @@
 				844FCCB3198B39F300EB242A /* State.swift */,
 				844FCCAF198B36BE00EB242A /* Test.swift */,
 				84572C2A1A6DBABA00241F68 /* Testable.swift */,
+				827749F71B65ABCC00A7965F /* Witness.swift */,
 				D46395B51B1A94D200AA1B65 /* Equatable.swift */,
 				844FCC90198B320500EB242A /* Supporting Files */,
 			);
@@ -417,6 +421,7 @@
 				844FCCAA198B323800EB242A /* Arbitrary.swift in Sources */,
 				8450D24A1AF8003800095EF6 /* TestOperators.swift in Sources */,
 				844FCCB4198B39F300EB242A /* State.swift in Sources */,
+				827749F81B65ABCC00A7965F /* Witness.swift in Sources */,
 				844FCCC7198EFB4700EB242A /* Rose.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +458,7 @@
 				84DF761A1B0BD58100C912B0 /* Rose.swift in Sources */,
 				84DF761B1B0BD58100C912B0 /* State.swift in Sources */,
 				84DF761C1B0BD58100C912B0 /* Test.swift in Sources */,
+				827749F91B65ABCC00A7965F /* Witness.swift in Sources */,
 				84DF761D1B0BD58100C912B0 /* Testable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -686,7 +692,7 @@
 				);
 				INFOPLIST_FILE = SwiftCheck/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
@@ -712,7 +718,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = SwiftCheck/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";

--- a/SwiftCheck/Arbitrary.swift
+++ b/SwiftCheck/Arbitrary.swift
@@ -284,6 +284,16 @@ extension Array where Element : Arbitrary {
 	}
 }
 
+extension Array : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : ([Element] -> Testable)) -> Property {
+		return forAllShrink([A].arbitrary, shrinker: [A].shrink, f: { bl in
+			return pf(bl.map(wit))
+		})
+	}
+}
+
 extension AnyBidirectionalCollection where Element : Arbitrary {
 	public static var arbitrary : Gen<AnyBidirectionalCollection<Element>> {
 		return AnyBidirectionalCollection.init <^> [Element].arbitrary
@@ -291,6 +301,16 @@ extension AnyBidirectionalCollection where Element : Arbitrary {
 	
 	public static func shrink(bl : AnyBidirectionalCollection<Element>) -> [AnyBidirectionalCollection<Element>] {
 		return [Element].shrink([Element](bl)).map(AnyBidirectionalCollection.init)
+	}
+}
+
+extension AnyBidirectionalCollection : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (AnyBidirectionalCollection<Element> -> Testable)) -> Property {
+		return forAllShrink(AnyBidirectionalCollection<A>.arbitrary, shrinker: AnyBidirectionalCollection<A>.shrink, f: { bl in
+			return pf(AnyBidirectionalCollection<Element>(bl.map(wit)))
+		})
 	}
 }
 
@@ -316,6 +336,16 @@ extension AnySequence where Element : Arbitrary {
 	}
 }
 
+extension AnySequence : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (AnySequence<Element> -> Testable)) -> Property {
+		return forAllShrink(AnySequence<A>.arbitrary, shrinker: AnySequence<A>.shrink, f: { bl in
+			return pf(AnySequence<Element>(bl.map(wit)))
+		})
+	}
+}
+
 extension ArraySlice where Element : Arbitrary {
 	public static var arbitrary : Gen<ArraySlice<Element>> {
 		return ArraySlice.init <^> [Element].arbitrary
@@ -326,9 +356,29 @@ extension ArraySlice where Element : Arbitrary {
 	}
 }
 
+extension ArraySlice : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (ArraySlice<Element> -> Testable)) -> Property {
+		return forAllShrink(ArraySlice<A>.arbitrary, shrinker: ArraySlice<A>.shrink, f: { bl in
+			return pf(ArraySlice<Element>(bl.map(wit)))
+		})
+	}
+}
+
 extension CollectionOfOne where Element : Arbitrary {
 	public static var arbitrary : Gen<CollectionOfOne<Element>> {
 		return CollectionOfOne.init <^> Element.arbitrary
+	}
+}
+
+extension CollectionOfOne : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (CollectionOfOne<Element> -> Testable)) -> Property {
+		return forAllShrink(CollectionOfOne<A>.arbitrary, shrinker: { _ in [] }, f: { (bl : CollectionOfOne<A>) -> Testable in
+			return pf(CollectionOfOne<Element>(wit(bl[.Zero])))
+		})
 	}
 }
 
@@ -349,6 +399,16 @@ extension Optional where T : Arbitrary {
 	}
 }
 
+extension Optional : WitnessedArbitrary {
+	public typealias Param = T
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> T)(pf : (Optional<T> -> Testable)) -> Property {
+		return forAllShrink(Optional<A>.arbitrary, shrinker: Optional<A>.shrink, f: { bl in
+			return pf(bl.map(wit))
+		})
+	}
+}
+
 extension ContiguousArray where Element : Arbitrary {
 	public static var arbitrary : Gen<ContiguousArray<Element>> {
 		return ContiguousArray.init <^> [Element].arbitrary
@@ -356,6 +416,16 @@ extension ContiguousArray where Element : Arbitrary {
 	
 	public static func shrink(bl : ContiguousArray<Element>) -> [ContiguousArray<Element>] {
 		return [Element].shrink([Element](bl)).map(ContiguousArray.init)
+	}
+}
+
+extension ContiguousArray : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (ContiguousArray<Element> -> Testable)) -> Property {
+		return forAllShrink(ContiguousArray<A>.arbitrary, shrinker: ContiguousArray<A>.shrink, f: { bl in
+			return pf(ContiguousArray<Element>(bl.map(wit)))
+		})
 	}
 }
 
@@ -400,7 +470,7 @@ extension HalfOpenInterval where Bound : protocol<Comparable, Arbitrary> {
 	}
 	
 	public static func shrink(bl : HalfOpenInterval<Bound>) -> [HalfOpenInterval<Bound>] {
-		return Zip2Sequence(Bound.shrink(bl.start), Bound.shrink(bl.end)).map(HalfOpenInterval.init)
+		return zip(Bound.shrink(bl.start), Bound.shrink(bl.end)).map(HalfOpenInterval.init)
 	}
 }
 
@@ -411,6 +481,16 @@ extension ImplicitlyUnwrappedOptional where T : Arbitrary {
 	
 	public static func shrink(bl : ImplicitlyUnwrappedOptional<T>) -> [ImplicitlyUnwrappedOptional<T>] {
 		return Optional<T>.shrink(bl).map(ImplicitlyUnwrappedOptional.init)
+	}
+}
+
+extension ImplicitlyUnwrappedOptional : WitnessedArbitrary {
+	public typealias Param = T
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> T)(pf : (ImplicitlyUnwrappedOptional<T> -> Testable)) -> Property {
+		return forAllShrink(ImplicitlyUnwrappedOptional<A>.arbitrary, shrinker: ImplicitlyUnwrappedOptional<A>.shrink, f: { bl in
+			return pf(bl.map(wit))
+		})
 	}
 }
 
@@ -458,6 +538,17 @@ extension Repeat where Element : Arbitrary {
 	}
 }
 
+extension Repeat : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (Repeat<Element> -> Testable)) -> Property {
+		return forAllShrink(Repeat<A>.arbitrary, shrinker: { _ in [] }, f: { bl in
+			let xs = bl.map(wit)
+			return pf(Repeat<Element>(count: xs.count, repeatedValue: xs.first!))
+		})
+	}
+}
+
 extension Set where Element : protocol<Arbitrary, Hashable> {
 	public static var arbitrary : Gen<Set<Element>> {
 		return Gen.sized { n in
@@ -473,6 +564,16 @@ extension Set where Element : protocol<Arbitrary, Hashable> {
 	
 	public static func shrink(s : Set<Element>) -> [Set<Element>] {
 		return [Element].shrink([Element](s)).map(Set.init)
+	}
+}
+
+extension Set : WitnessedArbitrary {
+	public typealias Param = Element
+	
+	public static func forAllWitnessed<A : Arbitrary>(wit : A -> Element)(pf : (Set<Element> -> Testable)) -> Property {
+		return forAll { (xs : [A]) in
+			return pf(Set<Element>(xs.map(wit)))
+		}
 	}
 }
 

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -389,7 +389,7 @@ private func protectResult(r : () throws -> TestResult) -> (() -> TestResult) {
 	return { protect(exception("Exception"))(x: r) }
 }
 
-private func id<A>(x : A) -> A {
+internal func id<A>(x : A) -> A {
 	return x
 }
 

--- a/SwiftCheck/Witness.swift
+++ b/SwiftCheck/Witness.swift
@@ -3,7 +3,7 @@
 //  SwiftCheck
 //
 //  Created by Robert Widmann on 7/26/15.
-//  Copyright © 2015 Robert Widmann. All rights reserved.
+//  Copyright © 2015 TypeLift. All rights reserved.
 //
 
 public protocol WitnessedArbitrary {

--- a/SwiftCheck/Witness.swift
+++ b/SwiftCheck/Witness.swift
@@ -1,0 +1,61 @@
+//
+//  Witness.swift
+//  SwiftCheck
+//
+//  Created by Robert Widmann on 7/26/15.
+//  Copyright © 2015 Robert Widmann. All rights reserved.
+//
+
+public protocol WitnessedArbitrary {
+	typealias Param
+	
+	static func forAllWitnessed<A : Arbitrary>(wit : A -> Param)(pf : (Self -> Testable)) -> Property
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for that type.
+public func forAll<A : WitnessedArbitrary where A.Param : Arbitrary>(pf : (A -> Testable)) -> Property {
+	return A.forAllWitnessed(id)(pf: pf)
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 2 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary>(pf : (A, B) -> Testable) -> Property {
+	return forAll({ t in forAll({ b in pf(t, b) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 3 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary>(pf : (A, B, C) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c in pf(t, b, c) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 4 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary, D : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary, D.Param : Arbitrary>(pf : (A, B, C, D) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c, d in pf(t, b, c, d) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 5 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary, D : WitnessedArbitrary, E : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary, D.Param : Arbitrary, E.Param : Arbitrary>(pf : (A, B, C, D, E) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c, d, e in pf(t, b, c, d, e) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 6 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary, D : WitnessedArbitrary, E : WitnessedArbitrary, F : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary, D.Param : Arbitrary, E.Param : Arbitrary, F.Param : Arbitrary>(pf : (A, B, C, D, E, F) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c, d, e, f in pf(t, b, c, d, e, f) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 7 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary, D : WitnessedArbitrary, E : WitnessedArbitrary, F : WitnessedArbitrary, G : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary, D.Param : Arbitrary, E.Param : Arbitrary, F.Param : Arbitrary, G.Param : Arbitrary>(pf : (A, B, C, D, E, F, G) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c, d, e, f, g in pf(t, b, c, d, e, f, g) }) })
+}
+
+/// Converts a function into a universally quantified property using the default shrinker and
+/// generator for 8 types.
+public func forAll<A : WitnessedArbitrary, B : WitnessedArbitrary, C : WitnessedArbitrary, D : WitnessedArbitrary, E : WitnessedArbitrary, F : WitnessedArbitrary, G : WitnessedArbitrary, H : WitnessedArbitrary where A.Param : Arbitrary, B.Param : Arbitrary, C.Param : Arbitrary, D.Param : Arbitrary, E.Param : Arbitrary, F.Param : Arbitrary, G.Param : Arbitrary, H.Param : Arbitrary>(pf : (A, B, C, D, E, F, G, H) -> Testable) -> Property {
+	return forAll({ t in forAll({ b, c, d, e, f, g, h in pf(t, b, c, d, e, f, g, h) }) })
+}

--- a/SwiftCheckTests/GenSpec.swift
+++ b/SwiftCheckTests/GenSpec.swift
@@ -46,12 +46,12 @@ class GenSpec : XCTestCase {
 			return forAll(g) { $0 == 0 }
 		}
 
-		property("Gen.elements only generates the elements of the given array") <- forAll { (xss : ArrayOf<Int>) in
-			if xss.getArray.isEmpty {
+		property("Gen.elements only generates the elements of the given array") <- forAll { (xss : Array<Int>) in
+			if xss.isEmpty {
 				return Discard()
 			}
-			let l = Set(xss.getArray)
-			return forAll(Gen.fromElementsOf(xss.getArray)) { l.contains($0) }
+			let l = Set(xss)
+			return forAll(Gen.fromElementsOf(xss)) { l.contains($0) }
 		}
 
 		property("Gen.elements only generates the elements of the given array") <- forAll { (n1 : Int, n2 : Int) in

--- a/SwiftCheckTests/PropertySpec.swift
+++ b/SwiftCheckTests/PropertySpec.swift
@@ -3,7 +3,7 @@
 //  SwiftCheck
 //
 //  Created by Robert Widmann on 6/5/15.
-//  Copyright (c) 2015 Robert Widmann. All rights reserved.
+//  Copyright (c) 2015 TypeLift. All rights reserved.
 //
 
 import XCTest

--- a/SwiftCheckTests/ShrinkSpec.swift
+++ b/SwiftCheckTests/ShrinkSpec.swift
@@ -3,7 +3,7 @@
 //  SwiftCheck
 //
 //  Created by Robert Widmann on 5/28/15.
-//  Copyright (c) 2015 Robert Widmann. All rights reserved.
+//  Copyright (c) 2015 TypeLift. All rights reserved.
 //
 
 import XCTest

--- a/SwiftCheckTests/ShrinkSpec.swift
+++ b/SwiftCheckTests/ShrinkSpec.swift
@@ -27,11 +27,11 @@ class ShrinkSpec : XCTestCase {
 			return (n != 0) ==> Set(self.shrinkArbitrary(n)).contains(0)
 		}
 
-		property("Shrinking a list never gives back the original") <- forAll { (l : ArrayOf<Int8>) in
-			return ArrayOf.shrink(l).map({ $0.getArray }).filter({ $0 == l.getArray }).isEmpty
+		property("Shrinking an array never gives back the original") <- forAll { (l : Array<Int8>) in
+			return Array.shrink(l).filter({ $0 == l }).isEmpty
 		}
 
-		property("Shrunken lists of integers always contain [] or [0]") <- forAll { (l : ArrayOf<Int>) in
+		property("Shrunken arrays of integers always contain [] or [0]") <- forAll { (l : ArrayOf<Int>) in
 			return (!l.getArray.isEmpty && l.getArray != [0]) ==> {
 				let ls = self.shrinkArbitrary(l).map { $0.getArray }
 				return (ls.filter({ $0 == [] || $0 == [0] }).count >= 1)

--- a/SwiftCheckTests/TestSpec.swift
+++ b/SwiftCheckTests/TestSpec.swift
@@ -3,7 +3,7 @@
 //  SwiftCheck
 //
 //  Created by Robert Widmann on 6/23/15.
-//  Copyright © 2015 Robert Widmann. All rights reserved.
+//  Copyright © 2015 TypeLift. All rights reserved.
 //
 
 import XCTest

--- a/SwiftCheckTests/TestSpec.swift
+++ b/SwiftCheckTests/TestSpec.swift
@@ -15,28 +15,28 @@ class TestSpec : XCTestCase {
 			return true
 		}
 
-		property("Optionals behave") <- forAllShrink(Optional<Int>.arbitrary, shrinker: Optional<Int>.shrink) { (xs : Int?) in
+		property("Optionals behave") <- forAll { (xs : Int?) in
 			return true
 		}
 
-		property("Sets behave") <- forAllShrink(Set<Int>.arbitrary, shrinker: Set<Int>.shrink) { (xs : Set<Int>) in
+		property("Sets behave") <- forAll { (xs : Set<Int>) in
 			return true
 		}
 
-		property("The reverse of the reverse of an array is that array") <- forAllShrink(Array<Int>.arbitrary, shrinker: Array<Int>.shrink) { (xs : Array<Int>) in
+		property("The reverse of the reverse of an array is that array") <- forAll { (xs : Array<Int>) in
 			return
 			(xs.reverse().reverse() == xs) <?> "Left identity"
 			^&&^
 			(xs == xs.reverse().reverse()) <?> "Right identity"
 		}
 
-		property("map behaves") <- forAllShrink(Array<Int>.arbitrary, shrinker: Array<Int>.shrink) { (xs : Array<Int>) in
+		property("map behaves") <- forAll { (xs : Array<Int>) in
 			return forAll { (f : ArrowOf<Int, Int>) in
 				return xs.map(f.getArrow) == xs.map(f.getArrow)
 			}
 		}
 
-		property("filter behaves") <- forAllShrink(Array<Int>.arbitrary, shrinker: Array<Int>.shrink) { (xs : Array<Int>) in
+		property("filter behaves") <- forAll { (xs : Array<Int>) in
 			return forAll { (pred : ArrowOf<Int, Bool>) in
 				let f = pred.getArrow
 				return (xs.filter(f).reduce(true, combine: { $0.0 && f($0.1) }) as Bool)


### PR DESCRIPTION
I was tired of having to write `forAllShrink` for so many types over and over again when the library can clearly infer all of that for us given a little bit more information than the usual `Arbitrary`.  Unfortunately, I wasn't able to make this one a sub-protocol of Arbitrary so they can't yet be mixed, but it's still exciting to be able to hide all the boilerplate for once.

For now, the protocol is named `WitnessedArbitrary` and only Functor-esque types of kind `* -> *` can adopt it (because we lack the means to extend tuples).