### PR TITLE
Print labels in verbose checks

### DIFF
--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -159,13 +159,13 @@ extension Testable {
 			let c = Callback.AfterTest(kind: .Counterexample, f: { (st, res) in
 				switch res.ok {
 				case .Some(true):
-					print("Passed: ", appendNewline: false)
+					print("\nPassed: ", appendNewline: false)
 					printLabels(res)
 				case .Some(false):
-					print("Failed: ", appendNewline: false)
+					print("\nFailed: ", appendNewline: false)
 					printLabels(res)
 				default:
-					print("Discarded: ", appendNewline: false)
+					print("\nDiscarded: ", appendNewline: false)
 					printLabels(res)
 				}
 			})

--- a/SwiftCheck/Property.swift
+++ b/SwiftCheck/Property.swift
@@ -159,11 +159,14 @@ extension Testable {
 			let c = Callback.AfterTest(kind: .Counterexample, f: { (st, res) in
 				switch res.ok {
 				case .Some(true):
-					print("Passed:")
+					print("Passed: ", appendNewline: false)
+					printLabels(res)
 				case .Some(false):
-					print("Failed:")
+					print("Failed: ", appendNewline: false)
+					printLabels(res)
 				default:
-					print("Discarded:")
+					print("Discarded: ", appendNewline: false)
+					printLabels(res)
 				}
 			})
 

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -354,7 +354,7 @@ internal func runATest(st : CheckerState)(f : (StdGen -> Int -> Prop)) -> Either
 
 internal func doneTesting(st : CheckerState)(f : (StdGen -> Int -> Prop)) -> Result {
 	if st.expectedFailure {
-		print("*** Passed " + "\(st.numSuccessTests)" + pluralize(" test", i: st.numSuccessShrinks))
+		print("*** Passed " + "\(st.numSuccessTests)" + pluralize(" test", i: st.numSuccessTests))
 		printDistributionGraph(st)
 		return .Success(numTests: st.numSuccessTests, labels: summary(st), output: "")
 	} else {
@@ -543,10 +543,10 @@ internal func cons<T>(lhs : T, var _ rhs : [T]) -> [T] {
 }
 
 private func pluralize(s : String, i : Int) -> String {
-	if i > 1 {
-		return s + "s"
+	if i == 0 {
+		return s
 	}
-	return s
+	return s + "s"
 }
 
 extension Array {

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -491,6 +491,19 @@ internal func labelPercentage(l : String, st : CheckerState) -> Int {
 	return (100 * occur.count) / st.maxSuccessTests
 }
 
+internal func printLabels(st : TestResult) {
+	if st.labels.isEmpty {
+		print("(.)")
+	} else if st.labels.count == 1, let pt = st.labels.first {
+		print("(\(pt.0))")
+	} else {
+		let gAllLabels = st.labels.map({ (l, _) in
+			return l + ", "
+		}).reduce("", combine: +)
+		print("("  + gAllLabels[gAllLabels.startIndex..<advance(gAllLabels.endIndex, -2)] + ")")
+	}
+}
+
 internal func printDistributionGraph(st : CheckerState) {
 	func showP(n : Int) -> String {
 		return (n < 10 ? " " : "") + "\(n)" + "%"

--- a/SwiftCheckTests/TestSpec.swift
+++ b/SwiftCheckTests/TestSpec.swift
@@ -29,6 +29,13 @@ class TestSpec : XCTestCase {
 			^&&^
 			(xs == xs.reverse().reverse()) <?> "Right identity"
 		}
+		
+		property("Failing conjunctions print labelled properties") <- forAll { (xs : Array<Int>) in
+			return
+				(xs.sort().sort() == xs.sort()).verbose <?> "Sort Left"
+				^&&^
+				((xs.sort() != xs.sort().sort()).verbose <?> "Bad Sort Right")
+		}.expectFailure
 
 		property("map behaves") <- forAll { (xs : Array<Int>) in
 			return forAll { (f : ArrowOf<Int, Int>) in


### PR DESCRIPTION
I have no idea why this worked the right way the first time around, but it does.  

New behavior for `.verbose` following the discussion in #74.