### PR TITLE
Publicize Checker Arguments API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: beta-xcode6.3
+osx_image: xcode7
 
 script:
     - xctool -project SwiftCheck.xcodeproj -scheme SwiftCheck -sdk macosx ONLY_ACTIVE_ARCH=NO clean build test

--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		8216BAB71B97775100A0D282 /* ComplexSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8216BAB61B97775100A0D282 /* ComplexSpec.swift */; settings = {ASSET_TAGS = (); }; };
-		8216BAB81B97775100A0D282 /* ComplexSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8216BAB61B97775100A0D282 /* ComplexSpec.swift */; settings = {ASSET_TAGS = (); }; };
+		8216BAB71B97775100A0D282 /* ComplexSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8216BAB61B97775100A0D282 /* ComplexSpec.swift */; };
+		8216BAB81B97775100A0D282 /* ComplexSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8216BAB61B97775100A0D282 /* ComplexSpec.swift */; };
 		827749F81B65ABCC00A7965F /* Witness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827749F71B65ABCC00A7965F /* Witness.swift */; };
 		827749F91B65ABCC00A7965F /* Witness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827749F71B65ABCC00A7965F /* Witness.swift */; };
 		82DD8EEC1B4CC88C00B66551 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DD8EEB1B4CC88C00B66551 /* Operators.swift */; };
@@ -338,6 +338,7 @@
 		844FCC84198B320500EB242A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Robert Widmann";
 				TargetAttributes = {

--- a/SwiftCheck/Arbitrary.swift
+++ b/SwiftCheck/Arbitrary.swift
@@ -742,14 +742,6 @@ private func bits<N : IntegerType>(n : N) -> Int {
 	return 1 + bits(n / 2)
 }
 
-private func inBounds<A : IntegerType>(fi : (Int -> A)) -> Gen<Int> -> Gen<A> {
-	return { g in
-		return fi <^> g.suchThat { x in
-			return (fi(x) as! Int) == x
-		}
-	}
-}
-
 private func nub<A : Hashable>(xs : [A]) -> [A] {
 	return [A](Set(xs))
 }

--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -20,7 +20,7 @@
 /// If necessary, arguments can be provided to this function to change the behavior of the testing
 /// mechanism:
 ///
-///     let args = CheckerArguments( replay: Optional.Some((standardRNG, 10)) // Replays all tests with a new generator of size 10
+///     let args = CheckerArguments( replay: Optional.Some((newStdGen(), 10)) // Replays all tests with a new generator of size 10
 ///                                , maxAllowableSuccessfulTests: 200 // Requires twice the normal amount of successes to pass.
 ///                                , maxAllowableDiscardedTests: 0 // Discards are not allowed anymore.
 ///                                , maxTestCaseSize: 1000 // Increase the size of tested values by 10x.

--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -15,7 +15,22 @@
 ///     }
 ///
 /// SwiftCheck will report all failures through the XCTest mechanism like a normal testing assert,
-/// but with minimal failing case reported as well.
+/// but with the minimal failing case reported as well.
+///
+/// If necessary, arguments can be provided to this function to change the behavior of the testing
+/// mechanism:
+///
+///     let args = CheckerArguments( replay: Optional.Some((standardRNG, 10)) // Replays all tests with a new generator of size 10
+///                                , maxAllowableSuccessfulTests: 200 // Requires twice the normal amount of successes to pass.
+///                                , maxAllowableDiscardedTests: 0 // Discards are not allowed anymore.
+///                                , maxTestCaseSize: 1000 // Increase the size of tested values by 10x.
+///                                )
+///
+///     property("reflexitivity", arguments: args) <- forAll { (i : Int8) in
+///	        return i == i
+///     }
+///
+/// If no arguments are provided, or nil is given, SwiftCheck will select an internal default.
 public func property(msg : String, arguments : CheckerArguments? = nil, file : String = __FILE__, line : UInt = __LINE__) -> AssertiveQuickCheck {
 	return AssertiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? stdArgs(msg))
 }
@@ -57,7 +72,7 @@ public struct ReportiveQuickCheck {
 /// Represents the arguments the test driver will use while performing testing, shrinking, and
 /// printing results.
 public struct CheckerArguments {
-	/// Provides a way of re-doing the test at the given size with a new generator.
+	/// Provides a way of re-doing a test at the given size with a new generator.
 	let replay : Optional<(StdGen, Int)>
 	/// The maximum number of test cases that must pass before the property itself passes.
 	///
@@ -99,6 +114,6 @@ public struct CheckerArguments {
 		self.name = name
 	}
 
-	internal var name	: String
+	internal var name : String
 }
 

--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -16,36 +16,50 @@
 ///
 /// SwiftCheck will report all failures through the XCTest mechanism like a normal testing assert,
 /// but with minimal failing case reported as well.
-public func property(msg : String, file : String = __FILE__, line : UInt = __LINE__) -> AssertiveQuickCheck {
-	return AssertiveQuickCheck(msg: msg, file: file, line: line)
+public func property(msg : String, arguments : CheckerArguments? = nil, file : String = __FILE__, line : UInt = __LINE__) -> AssertiveQuickCheck {
+	return AssertiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? stdArgs(msg))
 }
 
 public struct AssertiveQuickCheck {
 	let msg : String
 	let file : String
 	let line : UInt
+	let args : CheckerArguments
 
-	private init(msg : String, file : String, line : UInt) {
+	private init(msg : String, file : String, line : UInt, args : CheckerArguments) {
 		self.msg = msg
 		self.file = file
 		self.line = line
+		self.args = args
 	}
 }
 
 /// The interface for properties to be run through SwiftCheck without an XCTest assert.  The
 /// property will still generate console output during testing.
-public func reportProperty(msg : String, file : String = __FILE__, line : UInt = __LINE__) -> ReportiveQuickCheck {
-	return ReportiveQuickCheck(msg: msg, file: file, line: line)
+public func reportProperty(msg : String, arguments : CheckerArguments? = nil, file : String = __FILE__, line : UInt = __LINE__) -> ReportiveQuickCheck {
+	return ReportiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? stdArgs(msg))
 }
 
 public struct ReportiveQuickCheck {
 	let msg : String
 	let file : String
 	let line : UInt
+	let args : CheckerArguments
 
-	private init(msg : String, file : String, line : UInt) {
+	private init(msg : String, file : String, line : UInt, args : CheckerArguments) {
 		self.msg = msg
 		self.file = file
 		self.line = line
+		self.args = args
 	}
 }
+
+public struct CheckerArguments {
+	let name			: String
+	let replay			: Optional<(StdGen, Int)>
+	let maxSuccess		: Int
+	let maxDiscard		: Int
+	let maxSize			: Int
+	let chatty			: Bool
+}
+

--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -30,7 +30,7 @@ public struct AssertiveQuickCheck {
 		self.msg = msg
 		self.file = file
 		self.line = line
-		self.args = args
+		self.args = { var chk = args; chk.name = msg; return chk }()
 	}
 }
 
@@ -50,16 +50,55 @@ public struct ReportiveQuickCheck {
 		self.msg = msg
 		self.file = file
 		self.line = line
-		self.args = args
+		self.args = { var chk = args; chk.name = msg; return chk }()
 	}
 }
 
+/// Represents the arguments the test driver will use while performing testing, shrinking, and
+/// printing results.
 public struct CheckerArguments {
-	let name			: String
-	let replay			: Optional<(StdGen, Int)>
-	let maxSuccess		: Int
-	let maxDiscard		: Int
-	let maxSize			: Int
-	let chatty			: Bool
+	/// Provides a way of re-doing the test at the given size with a new generator.
+	let replay : Optional<(StdGen, Int)>
+	/// The maximum number of test cases that must pass before the property itself passes.
+	///
+	/// The default value of this property is 100.  In general, some tests may require more than
+	/// this amount, but less is rare.  If you need a value less than or equal to 1, use `.once`
+	/// on the property instead.
+	let maxAllowableSuccessfulTests : Int
+	/// The maximum number of tests cases that can be discarded before testing gives up on the
+	/// property.
+	///
+	/// The default value of this property is 500.  In general, most tests will require less than 
+	/// this amount.  `Discard`ed test cases do not affect the passing or failing status of the
+	/// property as a whole.
+	let maxAllowableDiscardedTests : Int
+	/// The limit to the size of all generators in the test.  
+	///
+	/// The default value of this property is 100.  If "large" values, in magnitude or
+	/// size, are necessary then increase this value, else keep it relatively near the default.  If
+	/// it becomes too small the samples present in the test case will lose diversity.
+	let maxTestCaseSize : Int
+
+	public init( replay : Optional<(StdGen, Int)>
+				, maxAllowableSuccessfulTests : Int
+				, maxAllowableDiscardedTests : Int
+				, maxTestCaseSize : Int) {
+		self = CheckerArguments(replay: replay, maxAllowableSuccessfulTests: maxAllowableSuccessfulTests, maxAllowableDiscardedTests: maxAllowableDiscardedTests, maxTestCaseSize: maxTestCaseSize, name: "")
+	}
+
+	internal init( replay : Optional<(StdGen, Int)>
+				, maxAllowableSuccessfulTests : Int
+				, maxAllowableDiscardedTests : Int
+				, maxTestCaseSize : Int
+				, name : String) {
+
+		self.replay = replay
+		self.maxAllowableSuccessfulTests = maxAllowableSuccessfulTests
+		self.maxAllowableDiscardedTests = maxAllowableDiscardedTests
+		self.maxTestCaseSize = maxTestCaseSize
+		self.name = name
+	}
+
+	internal var name	: String
 }
 

--- a/SwiftCheck/Modifiers.swift
+++ b/SwiftCheck/Modifiers.swift
@@ -373,6 +373,26 @@ private func undefined<A>() -> A {
 	fatalError("")
 }
 
+public struct Large<A : protocol<RandomType, LatticeType, IntegerType>> : Arbitrary {
+	public let getLarge : A
+
+	public init(_ lrg : A) {
+		self.getLarge = lrg
+	}
+
+	public var description : String {
+		return "Large( \(self.getLarge) )"
+	}
+
+	public static var arbitrary : Gen<Large<A>> {
+		return Gen<A>.choose((A.min, A.max)).fmap(Large.init)
+	}
+
+	public static func shrink(bl : Large<A>) -> [Large<A>] {
+		return bl.getLarge.shrinkIntegral.map(Large.init)
+	}
+}
+
 /// Guarantees that every generated integer is greater than 0.
 public struct Positive<A : protocol<Arbitrary, SignedNumberType>> : Arbitrary, CustomStringConvertible {
 	public let getPositive : A
@@ -452,5 +472,13 @@ public struct NonNegative<A : protocol<Arbitrary, IntegerType>> : Arbitrary, Cus
 extension NonNegative : CoArbitrary {
 	public static func coarbitrary<C>(x : NonNegative) -> (Gen<C> -> Gen<C>) {
 		return x.getNonNegative.coarbitraryIntegral()
+	}
+}
+
+private func inBounds<A : IntegerType where A.IntegerLiteralType == Int>(fi : (Int -> A)) -> Gen<Int> -> Gen<A> {
+	return { g in
+		return fi <^> g.suchThat { x in
+			return (fi(x) as! Int) == x
+		}
 	}
 }

--- a/SwiftCheck/Random.swift
+++ b/SwiftCheck/Random.swift
@@ -25,7 +25,7 @@ public protocol RandomGeneneratorType {
 }
 
 /// A library-provided standard random number generator.
-let standardRNG : StdGen = StdGen(time(nil))
+public let standardRNG : StdGen = StdGen(time(nil))
 
 public struct StdGen : RandomGeneneratorType {
 	let seed: Int

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -213,7 +213,7 @@ public func quickCheck(prop : Testable, name : String = "") {
 /// MARK: - Implementation Details
 
 internal func stdArgs(name : String = "") -> CheckerArguments {
-	return CheckerArguments(name: name, replay: .None, maxSuccess: 100, maxDiscard: 500, maxSize: 100, chatty: true)
+	return CheckerArguments(replay: .None, maxAllowableSuccessfulTests: 100, maxAllowableDiscardedTests: 500, maxTestCaseSize: 100, name: name)
 }
 
 internal enum Result {
@@ -269,12 +269,12 @@ internal func quickCheckWithResult(args : CheckerArguments, p : Testable) -> Res
 	let computeSize : Int -> Int -> Int = { x in
 		let computeSize_ : Int -> Int -> Int  = { x in
 			return { y in
-				if	roundTo(x)(m: args.maxSize) + args.maxSize <= args.maxSuccess ||
-					x >= args.maxSuccess ||
-					args.maxSuccess % args.maxSize == 0 {
-						return min(x % args.maxSize + (y / 10), args.maxSize)
+				if	roundTo(x)(m: args.maxTestCaseSize) + args.maxTestCaseSize <= args.maxAllowableSuccessfulTests ||
+					x >= args.maxAllowableSuccessfulTests ||
+					args.maxAllowableSuccessfulTests % args.maxTestCaseSize == 0 {
+						return min(x % args.maxTestCaseSize + (y / 10), args.maxTestCaseSize)
 				} else {
-					return min((x % args.maxSize) * args.maxSize / (args.maxSuccess % args.maxSize) + y / 10, args.maxSize)
+					return min((x % args.maxTestCaseSize) * args.maxTestCaseSize / (args.maxAllowableSuccessfulTests % args.maxTestCaseSize) + y / 10, args.maxTestCaseSize)
 				}
 			}
 		}
@@ -289,8 +289,8 @@ internal func quickCheckWithResult(args : CheckerArguments, p : Testable) -> Res
 
 
 	let istate = CheckerState(name: args.name
-							, maxAllowableSuccessfulTests:		args.maxSuccess
-							, maxAllowableDiscardedTests:	args.maxDiscard
+							, maxAllowableSuccessfulTests:		args.maxAllowableSuccessfulTests
+							, maxAllowableDiscardedTests:	args.maxAllowableDiscardedTests
 							, computeSize:			computeSize
 							, successfulTestCount:		0
 							, discardedTestCount:	0

--- a/SwiftCheck/TestOperators.swift
+++ b/SwiftCheck/TestOperators.swift
@@ -10,7 +10,7 @@ infix operator <- {}
 
 /// Binds a Testable value to a property.
 public func <-(checker : AssertiveQuickCheck, @autoclosure(escaping) test : () -> Testable) {
-	switch quickCheckWithResult(stdArgs(checker.msg), p: test()) {
+	switch quickCheckWithResult(checker.args, p: test()) {
 	case let .Failure(_, _, _, _, reason, _, _):
 		XCTFail(reason, file: checker.file, line: checker.line)
 	case .NoExpectedFailure(_, _, _):
@@ -22,7 +22,7 @@ public func <-(checker : AssertiveQuickCheck, @autoclosure(escaping) test : () -
 
 /// Binds a Testable value to a property.
 public func <-(checker : AssertiveQuickCheck, test : () -> Testable) {
-	switch quickCheckWithResult(stdArgs(checker.msg), p: test()) {
+	switch quickCheckWithResult(checker.args, p: test()) {
 	case let .Failure(_, _, _, _, reason, _, _):
 		XCTFail(reason, file: checker.file, line: checker.line)
 	case .NoExpectedFailure(_, _, _):
@@ -34,12 +34,12 @@ public func <-(checker : AssertiveQuickCheck, test : () -> Testable) {
 
 /// Binds a Testable value to a property.
 public func <-(checker : ReportiveQuickCheck, test : () -> Testable) {
-	quickCheckWithResult(stdArgs(checker.msg), p: test())
+	quickCheckWithResult(checker.args, p: test())
 }
 
 /// Binds a Testable value to a property.
 public func <-(checker : ReportiveQuickCheck, @autoclosure(escaping) test : () -> Testable) {
-	quickCheckWithResult(stdArgs(checker.msg), p: test())
+	quickCheckWithResult(checker.args, p: test())
 }
 
 infix operator ==> {

--- a/SwiftCheckTests/DiscardSpec.swift
+++ b/SwiftCheckTests/DiscardSpec.swift
@@ -13,5 +13,15 @@ class DiscardSpec : XCTestCase {
 	func testDiscardFailure() {
 		property("P != NP") <- Discard()
 		property("P = NP") <- Discard().expectFailure
+
+		let args = CheckerArguments(  replay: Optional.Some((standardRNG, 10))
+									, maxAllowableSuccessfulTests: 200
+									, maxAllowableDiscardedTests: 0
+									, maxTestCaseSize: 1000
+									)
+
+		property("Discards forbidden", arguments: args) <- forAll { (x : UInt) in
+			return Discard()
+		}.expectFailure
 	}
 }

--- a/SwiftCheckTests/DiscardSpec.swift
+++ b/SwiftCheckTests/DiscardSpec.swift
@@ -14,7 +14,7 @@ class DiscardSpec : XCTestCase {
 		property("P != NP") <- Discard()
 		property("P = NP") <- Discard().expectFailure
 
-		let args = CheckerArguments(  replay: Optional.Some((standardRNG, 10))
+		let args = CheckerArguments(  replay: Optional.Some((newStdGen(), 10))
 									, maxAllowableSuccessfulTests: 200
 									, maxAllowableDiscardedTests: 0
 									, maxTestCaseSize: 1000


### PR DESCRIPTION
Per the suggestion in #91, enables the passing of explicit arguments 