### PR TITLE
Give CheckerArguments default values

### DIFF
--- a/SwiftCheck/Check.swift
+++ b/SwiftCheck/Check.swift
@@ -32,7 +32,7 @@
 ///
 /// If no arguments are provided, or nil is given, SwiftCheck will select an internal default.
 public func property(msg : String, arguments : CheckerArguments? = nil, file : String = __FILE__, line : UInt = __LINE__) -> AssertiveQuickCheck {
-	return AssertiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? stdArgs(msg))
+	return AssertiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? CheckerArguments(name: msg))
 }
 
 public struct AssertiveQuickCheck {
@@ -52,7 +52,7 @@ public struct AssertiveQuickCheck {
 /// The interface for properties to be run through SwiftCheck without an XCTest assert.  The
 /// property will still generate console output during testing.
 public func reportProperty(msg : String, arguments : CheckerArguments? = nil, file : String = __FILE__, line : UInt = __LINE__) -> ReportiveQuickCheck {
-	return ReportiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? stdArgs(msg))
+	return ReportiveQuickCheck(msg: msg, file: file, line: line, args: arguments ?? CheckerArguments(name: msg))
 }
 
 public struct ReportiveQuickCheck {
@@ -94,19 +94,19 @@ public struct CheckerArguments {
 	/// it becomes too small the samples present in the test case will lose diversity.
 	let maxTestCaseSize : Int
 
-	public init(replay : Optional<(StdGen, Int)>
-			, maxAllowableSuccessfulTests : Int
-			, maxAllowableDiscardedTests : Int
-			, maxTestCaseSize : Int
+	public init(replay : Optional<(StdGen, Int)> = nil
+			, maxAllowableSuccessfulTests : Int = 100
+			, maxAllowableDiscardedTests : Int = 500
+			, maxTestCaseSize : Int = 100
 			)
 	{
 			self = CheckerArguments(replay: replay, maxAllowableSuccessfulTests: maxAllowableSuccessfulTests, maxAllowableDiscardedTests: maxAllowableDiscardedTests, maxTestCaseSize: maxTestCaseSize, name: "")
 	}
 
-	internal init(replay : Optional<(StdGen, Int)>
-				, maxAllowableSuccessfulTests : Int
-				, maxAllowableDiscardedTests : Int
-				, maxTestCaseSize : Int
+	internal init(replay : Optional<(StdGen, Int)> = nil
+				, maxAllowableSuccessfulTests : Int = 100
+				, maxAllowableDiscardedTests : Int = 500
+				, maxTestCaseSize : Int = 100
 				, name : String
 				)
 	{

--- a/SwiftCheck/Test.swift
+++ b/SwiftCheck/Test.swift
@@ -328,14 +328,10 @@ public func exists<A : Arbitrary>(gen : Gen<A>, pf : A throws -> Testable) -> Pr
 
 /// Tests a property and prints the results to stdout.
 public func quickCheck(prop : Testable, name : String = "") {
-	quickCheckWithResult(stdArgs(name), p: prop)
+	quickCheckWithResult(CheckerArguments(name: name), p: prop)
 }
 
 /// MARK: - Implementation Details
-
-internal func stdArgs(name : String = "") -> CheckerArguments {
-	return CheckerArguments(replay: .None, maxAllowableSuccessfulTests: 100, maxAllowableDiscardedTests: 500, maxTestCaseSize: 100, name: name)
-}
 
 internal enum Result {
 	case Success(numTests : Int


### PR DESCRIPTION
Instead of merely documenting the defaults, actually provide defaults
for the init arguments. This way clients can just say something like
`CheckerArguments(maxAllowableSuccessfulTests: 200)` and they'll get the
defaults for everything else.