### PR TITLE
Provide more efficient versions of ap and zip

### DIFF
--- a/Sources/Gen.swift
+++ b/Sources/Gen.swift
@@ -142,11 +142,10 @@ public struct Gen<A> {
 
 	/// Zips together 2 generators of type `A` and `B` into a generator of pairs.
 	public static func zip<A, B>(gen1 : Gen<A>, _ gen2 : Gen<B>) -> Gen<(A, B)> {
-		return gen1.flatMap { l in
-			return gen2.flatMap { r in
-				return Gen<(A, B)>.pure((l, r))
-			}
-		}
+		return Gen<(A, B)>(unGen: { r, n in
+			let (r1, r2) = r.split
+			return (gen1.unGen(r1, n), gen2.unGen(r2, n))
+		})
 	}
 }
 
@@ -283,11 +282,10 @@ extension Gen /*: Applicative*/ {
 /// Promotes function application to a Generator of functions applied to a 
 /// Generator of values.
 public func <*> <A, B>(fn : Gen<A -> B>, g : Gen<A>) -> Gen<B> {
-	return fn >>- { x1 in
-		return g >>- { x2 in
-			return Gen.pure(x1(x2))
-		}
-	}
+	return Gen(unGen: { r, n in
+		let (r1, r2) = r.split
+		return fn.unGen(r1, n)(g.unGen(r2, n))
+	})
 }
 
 extension Gen /*: Monad*/ {

--- a/Tests/GenSpec.swift
+++ b/Tests/GenSpec.swift
@@ -25,7 +25,7 @@ class GenSpec : XCTestCase {
 		property("Gen.frequency with N arguments behaves") <- forAll(Gen<Int>.choose((1, 1000))) { n in
 			return forAll(Gen.frequency(Array(count: n, repeatedValue: (1, Gen.pure(0))))) { $0 == 0 }
 		}
-
+		
 		property("Gen.weighted behaves") <- {
 			let g = Gen.weighted([
 				(10, 0),
@@ -146,6 +146,13 @@ class GenSpec : XCTestCase {
 		property("Gen.sequence occurs in order") <- forAll { (xs : [String]) in
 			return forAllNoShrink(sequence(xs.map(Gen.pure))) { ss in
 				return ss == xs
+			}
+		}
+		
+		property("Gen.zip behaves") <- forAll { (x : Int, y : Int) in
+			let g = Gen<(Int, Int)>.zip(Gen.pure(x), Gen.pure(y))
+			return forAllNoShrink(g) { (x1, y1) in
+				return (x1, y1) == (x, y)
 			}
 		}
 	}


### PR DESCRIPTION
What's in this pull request?
============================

The first versions of `ap` and `zip` suffered from a bug that caused them not to generate enough entropy by not splitting the RNG and instead distributing it to both generators.  This time, I've re-written the original buggy version with a split instead of two flatMaps which should make calling these common functions an order of magnitude faster since we only have to split once and don't have to create needless inner block invocations with a monadic tower.