### PR TITLE
Extend Replay Value Printing to All Failure Modes

### DIFF
--- a/Sources/TestOperators.swift
+++ b/Sources/TestOperators.swift
@@ -144,12 +144,12 @@ infix operator <- {}
 /// Binds a Testable value to a property.
 public func <- (checker : AssertiveQuickCheck, @autoclosure(escaping) test : () -> Testable) {
 	switch quickCheckWithResult(checker.args, test()) {
-	case let .Failure(_, sz, seed, _, reason, _, _):
+	case let .Failure(_, _, seed, sz, reason, _, _):
 		XCTFail(reason + "; Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
-	case .NoExpectedFailure(_, _, _):
-		XCTFail("Expected property to fail but it didn't.", file: checker.file, line: checker.line)
-	case .InsufficientCoverage(_, _, _):
-		XCTFail("Property coverage insufficient.", file: checker.file, line: checker.line)
+	case let .NoExpectedFailure(_, seed, sz, _, _):
+		XCTFail("Expected property to fail but it didn't.  Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
+	case let .InsufficientCoverage(_, seed, sz, _, _):
+		XCTFail("Property coverage insufficient.  Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
 	default:
 		return
 	}
@@ -158,12 +158,12 @@ public func <- (checker : AssertiveQuickCheck, @autoclosure(escaping) test : () 
 /// Binds a Testable value to a property.
 public func <- (checker : AssertiveQuickCheck, test : () -> Testable) {
 	switch quickCheckWithResult(checker.args, test()) {
-	case let .Failure(_, sz, seed, _, reason, _, _):
+	case let .Failure(_, _, seed, sz, reason, _, _):
 		XCTFail(reason + "; Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
-	case .NoExpectedFailure(_, _, _):
-		XCTFail("Expected property to fail but it didn't.", file: checker.file, line: checker.line)
-	case .InsufficientCoverage(_, _, _):
-		XCTFail("Property coverage insufficient.", file: checker.file, line: checker.line)
+	case let .NoExpectedFailure(_, seed, sz, _, _):
+		XCTFail("Expected property to fail but it didn't.  Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
+	case let .InsufficientCoverage(_, seed, sz, _, _):
+		XCTFail("Property coverage insufficient.  Replay with \(seed) and size \(sz)", file: checker.file, line: checker.line)
 	default:
 		return
 	}

--- a/Tests/PropertySpec.swift
+++ b/Tests/PropertySpec.swift
@@ -22,9 +22,9 @@ func ==(l : Property, r : Property) -> Bool {
 		return true
 	case (.ExistentialFailure(_, _, _, _, _, _, _), .ExistentialFailure(_, _, _, _, _, _, _)):
 		return true
-	case (.NoExpectedFailure(_, _, _), .NoExpectedFailure(_, _, _)):
+	case (.NoExpectedFailure(_, _, _, _, _), .NoExpectedFailure(_, _, _, _, _)):
 		return true
-	case (.InsufficientCoverage(_, _, _), .InsufficientCoverage(_, _, _)):
+	case (.InsufficientCoverage(_, _, _, _, _), .InsufficientCoverage(_, _, _, _, _)):
 		return true
 	default:
 		return false


### PR DESCRIPTION
What's in this pull request?
============================

- Fixes a bug where failure expectation and insufficient coverage failures wouldn't print replay values.