### PR TITLE
Add mapping functions for each zip function

### DIFF
--- a/Sources/Gen.swift
+++ b/Sources/Gen.swift
@@ -257,6 +257,60 @@ extension Gen /*: Cartesian*/ {
 			return (gen1.unGen(r1, n), gen2.unGen(r2, n), gen3.unGen(r3, n), gen4.unGen(r4, n), gen5.unGen(r5, n), gen6.unGen(r6, n), gen7.unGen(r7, n), gen8.unGen(r8, n), gen9.unGen(r9, n), gen10.unGen(r10, n))
 		})
 	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// two receivers create.
+	public static func map<A1, A2, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: (A1, A2) -> R) -> Gen<R> {
+		return zip(ga1, ga2).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// three receivers create.
+	public static func map<A1, A2, A3, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform: (A1, A2, A3) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// four receivers create.
+	public static func map<A1, A2, A3, A4, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform: (A1, A2, A3, A4) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// five receivers create.
+	public static func map<A1, A2, A3, A4, A5, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, transform: (A1, A2, A3, A4, A5) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// six receivers create.
+	public static func map<A1, A2, A3, A4, A5, A6, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform: (A1, A2, A3, A4, A5, A6) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5, ga6).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// seven receivers create.
+	public static func map<A1, A2, A3, A4, A5, A6, A7, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>,  _ ga7 : Gen<A7>, transform: (A1, A2, A3, A4, A5, A6, A7) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// eight receivers create.
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>,  _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform: (A1, A2, A3, A4, A5, A6, A7, A8) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// nine receivers create.
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>,  _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform: (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map(transform)
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// ten receivers create.
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, R>(ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4: Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>,  _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform: (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> R) -> Gen<R> {
+		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map(transform)
+	}
 }
 
 // MARK: Generator Modifiers
@@ -376,7 +430,7 @@ extension Gen /*: Applicative*/ {
 	}
 }
 
-/// Ap | Returns a Generator that uses the first given Generator to produce 
+/// Ap | Returns a Generator that uses the first given Generator to produce
 /// functions and the second given Generator to produce values that it applies 
 /// to those functions.  It can be used in conjunction with <^> to simplify the 
 /// application of "combining" functions to a large amount of sub-generators.  

--- a/Tests/GenSpec.swift
+++ b/Tests/GenSpec.swift
@@ -311,7 +311,7 @@ private func ==(l : Gen<Int>, r : Gen<Int>) -> Bool {
 ///
 /// - Returns: True *iff* `(a1, a2, a3) == (b1, b2, b3)`
 ///            where `lhs = Gen((a1, (a2, a3)))` and `rhs = Gen(((b1, b2), b3))`.
-private func ~= (lhs: Gen<(Int, (Int, Int))>, rhs: Gen<((Int, Int), Int)>) -> Bool {
+private func ~= (lhs : Gen<(Int, (Int, Int))>, rhs : Gen<((Int, Int), Int)>) -> Bool {
 	let normalizedL = lhs.map { ($0, $1.0, $1.1) }
 	let normalizedR = rhs.map { ($0.0, $0.1, $1) }
 

--- a/Tests/GenSpec.swift
+++ b/Tests/GenSpec.swift
@@ -155,7 +155,27 @@ class GenSpec : XCTestCase {
 				return (x1, y1) == (x, y)
 			}
 		}
-		
+
+		property("Gen.zip2 obeys the Cartesian associativity law") <- forAll { (x : Int, y : Int, z : Int) in
+			let rightBiasedZip: Gen<(Int, (Int, Int))> = .zip(.pure(x), .zip(.pure(y), .pure(z)))
+			let leftBiasedZip: Gen<((Int, Int), Int)> = .zip(.zip(.pure(x), .pure(y)), .pure(z))
+			return rightBiasedZip ~= leftBiasedZip
+		}
+
+		property("Gen.ap is consistent with Gen.zip2") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
+			let fx = Gen<Int>.pure(x)
+			let ff = Gen<ArrowOf<Int, Int>>.pure(f).map { $0.getArrow }
+			return fx.ap(ff) == Gen<(Int -> Int, Int)>.zip(ff, fx).map { f, x in f(x) }
+		}
+
+		property("Gen.zip2 obeys the Monoidal Functor left identity law") <- forAll { (x : Int) in
+			Gen<(Void, Int)>.zip(.pure(()), .pure(x)).map { $0.1 } == .pure(x)
+		}
+
+		property("Gen.zip2 obeys the Monoidal Functor right identity law") <- forAll { (x : Int) in
+			Gen<(Int, Void)>.zip(.pure(x), .pure(())).map { $0.0 } == .pure(x)
+		}
+
 		property("Gen.zip3 behaves") <- forAll { (x : Int, y : Int, z : Int) in
 			let g = Gen<(Int, Int, Int)>.zip(Gen.pure(x), Gen.pure(y), Gen.pure(z))
 			return forAllNoShrink(g) { (x1, y1, z1) in
@@ -285,4 +305,23 @@ internal func • <A, B, C>(f : B -> C, g : A -> B) -> A -> C {
 
 private func ==(l : Gen<Int>, r : Gen<Int>) -> Bool {
 	return l.proliferateSized(10).generate == r.proliferateSized(10).generate
+}
+
+/// `Gen` product is associative and has a natural isomorphism.
+///
+/// - Returns: True *iff* `(a1, a2, a3) == (b1, b2, b3)`
+///            where `lhs = Gen((a1, (a2, a3)))` and `rhs = Gen(((b1, b2), b3))`.
+private func ~= (lhs: Gen<(Int, (Int, Int))>, rhs: Gen<((Int, Int), Int)>) -> Bool {
+	let normalizedL = lhs.map { ($0, $1.0, $1.1) }
+	let normalizedR = rhs.map { ($0.0, $0.1, $1) }
+
+	let sampleSize = 10
+	let sampleL = normalizedL.proliferateSized(sampleSize).generate
+	let sampleR = normalizedR.proliferateSized(sampleSize).generate
+
+	for (tupleL, tupleR) in zip(sampleL, sampleR) {
+		guard tupleL == tupleR else { return false }
+	}
+
+	return true
 }

--- a/Tests/SimpleSpec.swift
+++ b/Tests/SimpleSpec.swift
@@ -51,13 +51,14 @@ extension ArbitraryLargeFoo : Arbitrary {
 				, Int.arbitrary, UInt.arbitrary)
 			.flatMap { t in
 				return Gen<(Bool, (Bool, Bool), (Bool, Bool, Bool), (Bool, Bool, Bool, Bool))>
-					.zip( Bool.arbitrary
-						, Gen<(Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary)
-						, Gen<(Bool, Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary, Bool.arbitrary)
-						, Gen<(Bool, Bool, Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary, Bool.arbitrary, Bool.arbitrary))
-					.map({ t2 in
-						return (t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t2.0, t2.1, t2.2, t2.3)
-					}).map(ArbitraryLargeFoo.init)
+					.map(
+						Bool.arbitrary,
+						Gen<(Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary),
+						Gen<(Bool, Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary, Bool.arbitrary),
+						Gen<(Bool, Bool, Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary, Bool.arbitrary, Bool.arbitrary)
+					) { t2 in
+						(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t2.0, t2.1, t2.2, t2.3)
+					}.map(ArbitraryLargeFoo.init)
 		}
 	}
 }


### PR DESCRIPTION
What's in this pull request?
============================

Adds functions `map(_:..._:transform:)` for each `zip` function. Also adds cartesian and monoidal functor tests to `Gen.zip2`

Why merge this pull request?
============================

In languages like Swift and Scala, the `liftAN` family of applicative functions are more convenient since currying isn't as convenient as it is in ML or Haskell, where `ap` or `<*>` is more natural. Adding these mapping functions simplifies generating more complex structures such as database models.

There was a gitter conversation that start the discussion on adding monoidal functions to `Gen` because applicative style, not only being inconvenient because of the force of currying, causing the type checker to trip on nested closures.

I'm assuming the majority of cases involving `zipN` are chained with `map` so these functions take care of the most common cases.

What's worth discussing about this pull request?
================================================

We can also add a family of `apN` functions. The signature would be something like, `ap2<A1, A2, R>(gf: Gen<(A1, A2) -> R>, ga1: Gen<A1>, ga2: Gen<A2>) -> Gen<R>`. The typelevel project cats provides these along with `mapN`.

Another discussion worth having is whether we want to keep up with the boilerplate of hand writing these functions or use a source generator like the Swift team's gyb script.

What downsides are there to merging this pull request?
======================================================

Only downside I can think of is API footprint. Since none of the added functions are primitives (they're all based on corresponding `zip` functions) I don't see this being a problem.
