### PR TITLE
Add Gen.compose to allow imperative generator composition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,15 @@ matrix:
         - set -o pipefail
         - xcodebuild test -scheme SwiftCheck | xcpretty -c
         # -- Start iOS --
+        # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
         - iOS_DEVICE_NAME="iPad Pro"
         - iOS_RUNTIME_VERSION="9.3"
-        # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
+        # Get simulator identifier for desired device/runtime pair
         - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
         - echo $SIMULATOR_ID
         - echo $iOS_DEVICE_NAME
         - echo $iOS_RUNTIME_VERSION
+        # !!!: Start simulator w/ desired device—helps avoid issues w/ Xcode timing out when waiting for simulator to become ready
         - open -b com.apple.iphonesimulator --args -CurrentDeviceUDID $SIMULATOR_ID
         - xcodebuild test -scheme SwiftCheck-iOS -destination "platform=iOS Simulator,name=${iOS_DEVICE_NAME},OS=${iOS_RUNTIME_VERSION}" | xcpretty -c
         # -- End iOS --

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,17 @@ matrix:
       script:
         - set -o pipefail
         - xcodebuild test -scheme SwiftCheck | xcpretty -c
-        - xcodebuild test -scheme SwiftCheck-iOS -destination 'platform=iOS Simulator,name=iPad Pro' | xcpretty -c
+        # -- Start iOS --
+        - iOS_DEVICE_NAME="iPad Pro"
+        - iOS_RUNTIME_VERSION="9.3"
+        # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
+        - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
+        - echo $SIMULATOR_ID
+        - echo $iOS_DEVICE_NAME
+        - echo $iOS_RUNTIME_VERSION
+        - open -b com.apple.iphonesimulator --args -CurrentDeviceUDID $SIMULATOR_ID
+        - xcodebuild test -scheme SwiftCheck-iOS -destination "platform=iOS Simulator,name=${iOS_DEVICE_NAME},OS=${iOS_RUNTIME_VERSION}" | xcpretty -c
+        # -- End iOS --
         - xcodebuild test -scheme SwiftCheck-tvOS -destination 'platform=tvOS Simulator,name=Apple TV 1080p' | xcpretty -c
     - os: linux
       language: generic

--- a/README.md
+++ b/README.md
@@ -230,6 +230,73 @@ class SimpleSpec : XCTestCase {
 }
 ```
 
+There's also a `Gen.compose` method which allows you to procedurally compose values from multiple generators to construct instances of a type:
+
+``` swift
+public struct ArbitraryLargeFoo {
+	let a : Int8
+	let b : Int16
+	let c : Int32
+	let d : Int64
+	let e : UInt8
+	let f : UInt16
+	let g : UInt32
+	let h : UInt64
+	let i : Int
+	let j : UInt
+	let k : Bool
+	let l : (Bool, Bool)
+	let m : (Bool, Bool, Bool)
+	let n : (Bool, Bool, Bool, Bool)
+	
+    public static var arbitrary: Gen<ArbitraryLargeFoo> = Gen<ArbitraryLargeFoo>.compose { c in
+        // c is a `GenComposer` which will generate the values you need, either from the default `arbitrary` member of the
+        // type or a given generator
+        let evenInt16 = Int16.arbitrary.suchThat { $0 % 2 == 0 }
+        return ArbitraryLargeFoo(
+            a: c.generate(), // `generate()` infers the type to return a value from `Int8.arbitrary`
+            b: c.generate(evenInt16), // returns a value from `evenInt16`
+            c: c.generate(),
+            d: c.generate(),
+            e: c.generate(),
+            f: c.generate(),
+            g: c.generate(),
+            h: c.generate(),
+            i: c.generate(),
+            j: c.generate(),
+            k: c.generate(),
+            l: (c.generate(), c.generate()),
+            m: (c.generate(), c.generate(), c.generate()),
+            n: (c.generate(), c.generate(), c.generate(), c.generate())
+        )   
+    }
+}
+
+```
+
+`Gen.compose` can also be used with types that can only be customized with setters:
+
+``` swift
+public struct ArbitraryMutableFoo : Arbitrary {
+    var a: Int8
+    var b: Int16
+    
+    public init() {
+        a = 0
+        b = 0
+    }
+    
+    public static var arbitrary: Gen<ArbitraryMutableFoo> {
+        return Gen.compose { c in
+            var foo = ArbitraryMutableFoo()
+            foo.a = c.generate()
+            foo.b = c.generate()
+            return foo
+        }
+    }
+}
+```
+
 For everything else, SwiftCheck defines a number of combinators to make working
 with custom generators as simple as possible:
 

--- a/Sources/Modifiers.swift
+++ b/Sources/Modifiers.swift
@@ -652,7 +652,7 @@ private final class PointerOfImpl<T : Arbitrary> : Arbitrary {
 /// Class used to generate values from mulitple `Gen` instances.
 /// 
 /// Given a StdGen and size, generate values from other generators, splitting the StdGen
-/// after each call to `generate`, ensuring suffiicent entropy across generators.
+/// after each call to `generate`, ensuring sufficient entropy across generators.
 /// 
 /// - seealso: Gen.compose
 public final class GenComposer {
@@ -676,12 +676,11 @@ public final class GenComposer {
     /// - parameter gen: The generator used to create a random value.
     /// 
     /// - returns: A random `T` using the receiver's stdgen and size.
-    ///
     public func generate<T>(gen: Gen<T>) -> T {
         return gen.unGen(split(), size)
     }
     
-    ///  Generate a new `T` with it's default `arbitrary` generator.
+    ///  Generate a new `T` with its default `arbitrary` generator.
     ///
     ///  - returns: A random `T`.
     ///

--- a/Sources/Modifiers.swift
+++ b/Sources/Modifiers.swift
@@ -649,3 +649,80 @@ private final class PointerOfImpl<T : Arbitrary> : Arbitrary {
 	}
 }
 
+/**
+ Class used to generate values from mulitple `Gen` instances.
+ 
+ Given a StdGen and size, generate values from other generators, splitting the StdGen
+ after each call to `generate`, ensuring suffiicent entropy across generators.
+ 
+ - seealso: Gen.compose
+*/
+public final class GenComposer {
+    var stdgen: StdGen
+    var size: Int
+    
+    init(stdgen: StdGen, size: Int) {
+        self.stdgen = stdgen
+        self.size = size
+    }
+    
+    // Split internal StdGen to ensure sufficient entropy over multiple `generate` calls.
+    private func split() -> StdGen {
+        let old = stdgen
+        stdgen = old.split.0
+        return old
+    }
+    
+    /// Generate a new `T` with a specific generator.
+    ///
+    /// - parameter gen: The generator used to create a random value.
+    /// 
+    /// - returns: A random `T` using the receiver's stdgen and size.
+    ///
+    public func generate<T>(gen: Gen<T>) -> T {
+        return gen.unGen(split(), size)
+    }
+    
+    ///  Generate a new `T` with it's default `arbitrary` generator.
+    ///
+    ///  - returns: A random `T`.
+    ///
+    ///  - seealso: generate\<T\>(gen:)
+    public func generate<T where T: Arbitrary>() -> T {
+        return generate(T.arbitrary)
+    }
+}
+
+extension Gen {
+    /**
+     Create a generator by procedurally composing generated values from other generators.
+     
+     This is useful in cases where it's cumbersome to functionally compose multiple
+     generators using `zip` and `map`. For example:
+     
+         public static var arbitrary: Gen<ArbitraryLargeFoo> {
+             return Gen<ArbitraryLargeFoo>.compose { c in
+                 return ArbitraryLargeFoo(
+                     // use the nullary method to get an `arbitrary` value
+                     a: c.generate(),
+     
+                     // or pass a custom generator
+                     b: c.generate(Bool.suchThat { $0 == false }),
+     
+                     // .. and so on, for as many values & types as you need
+                     c: c.generate(), ...
+                 )
+             }
+         }
+     
+     - parameter build: Function which is passed a GenComposer which can be used
+     
+     - returns: A generator which uses the `build` function to create arbitrary instances of `A`.
+     */
+    public static func compose(build: GenComposer -> A) -> Gen<A> {
+        return Gen(unGen: { (stdgen, size) -> A in
+            let composer = GenComposer(stdgen: stdgen, size: size)
+            return build(composer)
+        })
+    }
+}

--- a/Sources/Modifiers.swift
+++ b/Sources/Modifiers.swift
@@ -658,8 +658,8 @@ private final class PointerOfImpl<T : Arbitrary> : Arbitrary {
  - seealso: Gen.compose
 */
 public final class GenComposer {
-    var stdgen: StdGen
-    var size: Int
+    private var stdgen: StdGen
+    private var size: Int
     
     init(stdgen: StdGen, size: Int) {
         self.stdgen = stdgen

--- a/Sources/Modifiers.swift
+++ b/Sources/Modifiers.swift
@@ -649,14 +649,12 @@ private final class PointerOfImpl<T : Arbitrary> : Arbitrary {
 	}
 }
 
-/**
- Class used to generate values from mulitple `Gen` instances.
- 
- Given a StdGen and size, generate values from other generators, splitting the StdGen
- after each call to `generate`, ensuring suffiicent entropy across generators.
- 
- - seealso: Gen.compose
-*/
+/// Class used to generate values from mulitple `Gen` instances.
+/// 
+/// Given a StdGen and size, generate values from other generators, splitting the StdGen
+/// after each call to `generate`, ensuring suffiicent entropy across generators.
+/// 
+/// - seealso: Gen.compose
 public final class GenComposer {
     private var stdgen: StdGen
     private var size: Int
@@ -694,31 +692,29 @@ public final class GenComposer {
 }
 
 extension Gen {
-    /**
-     Create a generator by procedurally composing generated values from other generators.
-     
-     This is useful in cases where it's cumbersome to functionally compose multiple
-     generators using `zip` and `map`. For example:
-     
-         public static var arbitrary: Gen<ArbitraryLargeFoo> {
-             return Gen<ArbitraryLargeFoo>.compose { c in
-                 return ArbitraryLargeFoo(
-                     // use the nullary method to get an `arbitrary` value
-                     a: c.generate(),
-     
-                     // or pass a custom generator
-                     b: c.generate(Bool.suchThat { $0 == false }),
-     
-                     // .. and so on, for as many values & types as you need
-                     c: c.generate(), ...
-                 )
-             }
-         }
-     
-     - parameter build: Function which is passed a GenComposer which can be used
-     
-     - returns: A generator which uses the `build` function to create arbitrary instances of `A`.
-     */
+    /// Create a generator by procedurally composing generated values from other generators.
+    /// 
+    /// This is useful in cases where it's cumbersome to functionally compose multiple
+    /// generators using `zip` and `map`. For example:
+    /// 
+    ///     public static var arbitrary: Gen<ArbitraryLargeFoo> {
+    ///         return Gen<ArbitraryLargeFoo>.compose { c in
+    ///             return ArbitraryLargeFoo(
+    ///                 // use the nullary method to get an `arbitrary` value
+    ///                 a: c.generate(),
+    /// 
+    ///                 // or pass a custom generator
+    ///                 b: c.generate(Bool.suchThat { $0 == false }),
+    /// 
+    ///                 // .. and so on, for as many values & types as you need
+    ///                 c: c.generate(), ...
+    ///             )
+    ///         }
+    ///     }
+    /// 
+    /// - parameter build: Function which is passed a GenComposer which can be used
+    /// 
+    /// - returns: A generator which uses the `build` function to create arbitrary instances of `A`.
     public static func compose(build: GenComposer -> A) -> Gen<A> {
         return Gen(unGen: { (stdgen, size) -> A in
             let composer = GenComposer(stdgen: stdgen, size: size)

--- a/Tests/SimpleSpec.swift
+++ b/Tests/SimpleSpec.swift
@@ -41,6 +41,26 @@ public struct ArbitraryLargeFoo {
 	let n : (Bool, Bool, Bool, Bool)
 }
 
+extension ArbitraryLargeFoo: Equatable {}
+
+public func ==(i: ArbitraryLargeFoo, j: ArbitraryLargeFoo) -> Bool {
+    return
+        i.a == j.a
+        && i.b == j.b
+        && i.c == j.c
+        && i.d == j.d
+        && i.e == j.e
+        && i.f == j.f
+        && i.g == j.g
+        && i.h == j.h
+        && i.i == j.i
+        && i.j == j.j
+        && i.k == j.k
+        && i.l == j.l
+        && i.m == j.m
+        && i.n == j.n
+}
+
 extension ArbitraryLargeFoo : Arbitrary {
 	public static var arbitrary : Gen<ArbitraryLargeFoo> {
 		return Gen<(Int8, Int16, Int32, Int64
@@ -124,6 +144,30 @@ class SimpleSpec : XCTestCase {
 				return op(x, y) ==== !iop(x, y)
 			}
 		}
+        
+        let composedArbitraryLargeFoo = Gen<ArbitraryLargeFoo>.compose { c in
+            return ArbitraryLargeFoo(
+                a: c.generate(),
+                b: c.generate(),
+                c: c.generate(),
+                d: c.generate(),
+                e: c.generate(),
+                f: c.generate(),
+                g: c.generate(),
+                h: c.generate(),
+                i: c.generate(),
+                j: c.generate(),
+                k: c.generate(),
+                l: (c.generate(), c.generate()),
+                m: (c.generate(), c.generate(), c.generate()),
+                n: (c.generate(), c.generate(), c.generate(), c.generate())
+            )   
+        }
+        
+        property("composition generates high-entropy, arbitrary values")
+        <- forAll(composedArbitraryLargeFoo, composedArbitraryLargeFoo) { a, b in
+            return a != b
+        }
 	}
 }
 


### PR DESCRIPTION
What's in this pull request?
============================

Swift's lack of implicit conformance and polyvariadic functions makes composing generators using `map`/`zip` or functional operators (`<*>` and `<^>`) cumbersome and/or infeasible for types with a large number of input parameters.  Further, manually gathering many generated values to create a new generator is not only vulnerable to losing entropy\*, but also rife with duplicated calls to [manually split the StdGen](https://gist.github.com/bgerstle/91760b54c0b7dcf1d8fa6cff5cf25765)—not to mention making `Gen(ungen:)` public 🙈. 

This change introduces `GenComposer`, which preserves entropy by encapsulating the logic of splitting the StdGen, as well as offering generic functions to remove even more boilerplate—especially for the default use case (`T.arbitrary`).

\* As discussed in gitter preceding https://github.com/typelift/SwiftCheck/pull/164

Why merge this pull request?
============================

- Circumvents limitations of Swift's type system & performance problems with the type checker
- Very small code footprint
- Zero impact on build processes

What's worth discussing about this pull request?
================================================

- Where the code lives (Modifiers.swift, Gen.swift, etc.)
- API naming
- Code (and comment) clarity
- How/where to introduce `Gen.compose` in the documenation
- Missing tests

What downsides are there to merging this pull request?
======================================================

- Yet another way to compose `Gen` instances (in addition to `zip`, `flatMap`, etc.)