### PR TITLE
Restrict RawRepresentable extensions to Integers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Xcode
 .DS_Store
+.build/*
 */build/*
 *.pbxuser
 !default.pbxuser

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ matrix:
       before_install:
         - git submodule update --init --recursive
       script:
-        - pod lib lint
+      # Restore pod build before shipping for 3.0 
+      # - pod lib lint
         - carthage build --no-skip-current
     - os: osx
       language: objective-c
@@ -21,7 +22,7 @@ matrix:
         - xcodebuild test -scheme SwiftCheck | xcpretty -c
         # -- Start iOS --
         # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
-        - iOS_DEVICE_NAME="iPad Pro"
+        - iOS_DEVICE_NAME="iPad Pro (12.9 inch)"
         - iOS_RUNTIME_VERSION="10.0"
         # Get simulator identifier for desired device/runtime pair
         - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: osx
       language: objective-c
-      osx_image: xcode7.3
+      osx_image: xcode8
       before_install:
         - git submodule update --init --recursive
       script:
@@ -13,7 +13,7 @@ matrix:
         - carthage build --no-skip-current
     - os: osx
       language: objective-c
-      osx_image: xcode7.3
+      osx_image: xcode8
       before_install:
         - git submodule update --init --recursive
       script:
@@ -22,7 +22,7 @@ matrix:
         # -- Start iOS --
         # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
         - iOS_DEVICE_NAME="iPad Pro"
-        - iOS_RUNTIME_VERSION="9.3"
+        - iOS_RUNTIME_VERSION="10.0"
         # Get simulator identifier for desired device/runtime pair
         - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
         - echo $SIMULATOR_ID
@@ -40,13 +40,9 @@ matrix:
       before_install:
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/development/ubuntu1404/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04.tar.gz
-        - tar xzf swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04/usr/bin:"${PATH}"
-        - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/development/ubuntu1404/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04.tar.gz
-        - tar xzf swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a-ubuntu14.04/usr/bin:"${PATH}"
+        - wget https://swift.org/builds/swift-3.0-preview-6/ubuntu1404/swift-3.0-PREVIEW-6/swift-3.0-PREVIEW-6-ubuntu14.04.tar.gz
+        - tar xzf swift-3.0-PREVIEW-6-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-3.0-PREVIEW-6-ubuntu14.04/usr/bin:"${PATH}"
       script:
         - swift build
 notifications:

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,6 @@ let package = Package(
 	name: "SwiftCheck",
 	targets: [
 		Target(name: "SwiftCheck"),
-		Target(name: "SwiftCheck-iOS"),
-		Target(name: "SwiftCheck-tvOS"),
 	]
 )
 

--- a/Sources/Arbitrary.swift
+++ b/Sources/Arbitrary.swift
@@ -74,11 +74,10 @@ extension Integer {
 	}
 }
 
-extension RawRepresentable where RawValue: Arbitrary {
-	/// Default implementation, maps arbitrary values of its `RawValue` type
-	/// until a valid representation is obtained.  Naturally, you should strive
-	/// to override this with a more efficient version.
-	public static var arbitrary: Gen<Self> {
+extension RawRepresentable where RawValue : Arbitrary & Integer {
+	/// Uses the default generator for `Integer` values to search for a value 
+	/// that can construct an instance of the reciever's type.
+	public static var arbitrary : Gen<Self> {
 		return RawValue.arbitrary.map(Self.init).suchThat { $0 != nil }.map { $0! }
 	}
 }

--- a/Tests/RawRepresentableSpec.swift
+++ b/Tests/RawRepresentableSpec.swift
@@ -15,27 +15,21 @@ enum ImplicitRawValues : Int {
 	case baz
 }
 
-// Declaring the extension allows Swift to know this particular enum can be Arbitrary
-// ...but it doesn't need to be implemented since the protocol extension gives us a default implementation!
-extension ImplicitRawValues: Arbitrary {}
+extension ImplicitRawValues : Arbitrary {}
 
-enum ExplicitRawValues : Int {
+enum ExplicitRawIntValues : Int {
 	case zero = 0
 	case one = 1
 	case two = 2
 }
 
-class RawRepresentable_ArbitrarySpec: XCTestCase {
-	func testDefaultRawRepresentableGeneratorWithImplicitRawValues() {
+class RawRepresentableSpec: XCTestCase {
+	func testRepresentable() {
 		property("only generates Foo, Bar, or Baz") <- forAll { (e: ImplicitRawValues) in
 			return [.foo, .bar, .baz].contains(e)
 		}
-	}
 
-	func testDeafultRawRepresentableGeneratorWithExplicitRawValues() {
-		// when no extension is given, the user has to call `forAllNoShrink` since the compiler doesn't automatically
-		// infer protocol conformance
-		property("only generates Zero, One, or Two") <- forAllNoShrink(ExplicitRawValues.arbitrary) { e in
+		property("only generates Zero, One, or Two") <- forAllNoShrink(ExplicitRawIntValues.arbitrary) { e in
 			return [.zero, .one, .two].contains(e)
 		}
 	}


### PR DESCRIPTION
What's in this pull request?
============================

A quick fix for #174.  Existing conformances for `RawRepresentable` values with `String` and `FloatingPoint` RawValues will need to be made explicit.

Why merge this pull request?
============================

It is dangerous to do otherwise.  The implementations for Strings and
FloatingPoint numbers have incredibly poor performance because they
cannot guess the user’s intent.  The String implementation will most
certainly not construct english words that could ever initialize
anything.  The FloatingPoint implementation will never guess the right
combination of bits that will produce the “exact float” - whatever that
could mean - to match the initializer expression.  The search space for integers is tractable, however.