### PR TITLE
Remove gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/Operadics"]
-	path = Carthage/Checkouts/Operadics
-	url = https://github.com/typelift/Operadics.git


### PR DESCRIPTION
This submodule was removed but we never cleaned up the gitmodules file. This
resulted in errors when trying to check out the project using Carthage.