### PR TITLE
Bring our featureset up to par with QuickCheck

### DIFF
--- a/Sources/Check.swift
+++ b/Sources/Check.swift
@@ -84,7 +84,7 @@ public struct CheckerArguments {
 	/// passes.
 	///
 	/// The default value of this property is 100.  In general, some tests may require more than
-	/// this amount, but less is rare.  If you need a value less than or equal to 1, use `.once`
+	/// this amount, but less is rare.  If you need a value of 1, use `.once`
 	/// on the property instead.
 	let maxAllowableSuccessfulTests : Int
 	/// The maximum number of tests cases that can be discarded before testing gives up on the

--- a/Sources/Check.swift
+++ b/Sources/Check.swift
@@ -84,7 +84,7 @@ public struct CheckerArguments {
 	/// passes.
 	///
 	/// The default value of this property is 100.  In general, some tests may require more than
-	/// this amount, but less is rare.  If you need a value of 1, use `.once`
+	/// this amount, but less is rare.  If you need a value of 1 use `.once`
 	/// on the property instead.
 	let maxAllowableSuccessfulTests : Int
 	/// The maximum number of tests cases that can be discarded before testing gives up on the

--- a/Sources/Gen.swift
+++ b/Sources/Gen.swift
@@ -90,6 +90,12 @@ public struct Gen<A> {
 		})
 	}
 
+	/// Constructs a generator by applying the given function to the minimum 
+	/// and maximum bounds of a bounded type.
+	public static func withBounds<A : LatticeType>(_ f : @escaping (A, A) -> Gen<A>) -> Gen<A> {
+		return f(A.min, A.max)
+	}
+	
 	/// Constructs a random element in the range of two `RandomType`s.
 	///
 	/// When using this function, it is necessary to explicitly specialize the
@@ -101,6 +107,18 @@ public struct Gen<A> {
 			return A.randomInRange(rng, gen: s).0
 		})
 	}
+	
+	/// Constructs a random element in the range of a bounded `RandomType`.
+	///
+	/// When using this function, it is necessary to explicitly specialize the
+	/// generic parameter `A`.  For example:
+	///
+	///     Gen<UInt32>.chooseAny().flatMap(Gen<Character>.pure • Character.init • UnicodeScalar.init)
+	public static func chooseAny<A : RandomType & LatticeType>() -> Gen<A> {
+		return Gen<A>(unGen: { (s, _) in
+			return randomBound(s).0
+		})
+	}
 
 	/// Constructs a Generator that randomly selects and uses a particular
 	/// generator from the given sequence of Generators.
@@ -108,7 +126,7 @@ public struct Gen<A> {
 	/// If control over the distribution of generators is needed, see
 	/// `Gen.frequency` or `Gen.weighted`.
 	public static func oneOf<S : BidirectionalCollection>(_ gs : S) -> Gen<A>
-		where S.Iterator.Element == Gen<A>, S.Index : RandomType & Comparable, S.Index : RandomType
+		where S.Iterator.Element == Gen<A>, S.Index : RandomType & Comparable
 	{
 		assert(gs.count != 0, "oneOf used with empty list")
 

--- a/Sources/Gen.swift
+++ b/Sources/Gen.swift
@@ -90,13 +90,7 @@ public struct Gen<A> {
 		})
 	}
 
-	/// Constructs a generator by applying the given function to the minimum 
-	/// and maximum bounds of a bounded type.
-	public static func withBounds<A : LatticeType>(_ f : @escaping (A, A) -> Gen<A>) -> Gen<A> {
-		return f(A.min, A.max)
-	}
-	
-	/// Constructs a random element in the range of two `RandomType`s.
+	/// Constructs a random element in the inclusive range of two `RandomType`s.
 	///
 	/// When using this function, it is necessary to explicitly specialize the
 	/// generic parameter `A`.  For example:

--- a/Sources/Random.swift
+++ b/Sources/Random.swift
@@ -218,7 +218,7 @@ extension UInt : RandomType {
 	/// Returns a random `UInt` value using the given range and generator.
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt, UInt), gen : G) -> (UInt, G) {
 		let (minl, maxl) = range
-		let (bb, gg) = Int64.randomInRange((Int64(Int(bitPattern: minl)), Int64(Int(bitPattern: maxl))), gen: gen)
+		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
 		return (UInt(truncatingBitPattern: bb), gg)
 	}
 }
@@ -227,7 +227,7 @@ extension UInt8 : RandomType {
 	/// Returns a random `UInt8` value using the given range and generator.
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt8, UInt8), gen : G) -> (UInt8, G) {
 		let (minl, maxl) = range
-		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
+		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
 		return (UInt8(truncatingBitPattern: bb), gg)
 	}
 }
@@ -236,7 +236,7 @@ extension UInt16 : RandomType {
 	/// Returns a random `UInt16` value using the given range and generator.
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt16, UInt16), gen : G) -> (UInt16, G) {
 		let (minl, maxl) = range
-		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
+		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
 		return (UInt16(truncatingBitPattern: bb), gg)
 	}
 }
@@ -245,7 +245,7 @@ extension UInt32 : RandomType {
 	/// Returns a random `UInt32` value using the given range and generator.
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt32, UInt32), gen : G) -> (UInt32, G) {
 		let (minl, maxl) = range
-		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
+		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
 		return (UInt32(truncatingBitPattern: bb), gg)
 	}
 }

--- a/Sources/Test.swift
+++ b/Sources/Test.swift
@@ -450,7 +450,7 @@ public func forAllShrink<A>(_ gen : Gen<A>, shrinker : @escaping (A) -> [A], f :
 				return TestResult.failed("Test case threw an exception: \"\(e)\"").counterexample(String(describing: xs))
 			}
 		}).unProperty
-	})
+	}).again
 }
 
 /// Converts a function into an existentially quantified property using the
@@ -581,8 +581,7 @@ internal func quickCheckWithResult(_ args : CheckerArguments, _ p : Testable) ->
 		arguments:                    args,
 		silence:                      args.silence
 	)
-	let modP : Property = (p.exhaustive ? p.property.once : p.property)
-	return test(istate, caseGen: modP.unProperty.unGen)
+	return test(istate, caseGen: p.property.unProperty.unGen)
 }
 
 // Main Testing Loop:

--- a/Sources/Testable.swift
+++ b/Sources/Testable.swift
@@ -16,22 +16,9 @@
 /// and `Property`.  The last of these enables `forAll`s to return further
 /// `forAll`s that can depend on previously generated values.
 public protocol Testable {
-	/// Returns true iff a single test case is exhaustive i.e. adequately covers
-	/// the search space.
-	///
-	/// If true, the property will only be tested once.  Defaults to false.
-	var exhaustive : Bool { get }
-
 	/// Returns a `Property`, which SwiftCheck uses to perform test case
 	/// generation.
 	var property : Property { get }
-}
-
-extension Testable {
-	/// By default, all `Testable` types are non-exhaustive.
-	public var exhaustive : Bool {
-		return false
-	}
 }
 
 /// A property is anything that generates `Prop`s.
@@ -58,10 +45,6 @@ public struct Property : Testable {
 public struct Prop : Testable {
 	var unProp : Rose<TestResult>
 
-	/// `Prop` tests are exhaustive because they unwrap to reveal non-exhaustive
-	/// property tests.
-	public var exhaustive : Bool { return true }
-
 	/// Returns a property that tests the receiver.
 	public var property : Property {
 		//        return Property(Gen.pure(Prop(unProp: .IORose(protectRose({ self.unProp })))))
@@ -71,9 +54,6 @@ public struct Prop : Testable {
 
 /// When returned from a test case, that particular case is discarded.
 public struct Discard : Testable {
-	/// `Discard`s are trivially exhaustive.
-	public var exhaustive : Bool { return true }
-
 	/// Create a `Discard` suitable for
 	public init() { }
 
@@ -84,9 +64,6 @@ public struct Discard : Testable {
 }
 
 extension TestResult : Testable {
-	/// `TestResult`s are trivially exhaustive.
-	public var exhaustive : Bool { return true }
-
 	/// Returns a property that tests the receiver.
 	public var property : Property {
 		return Property(Gen.pure(Prop(unProp: Rose.pure(self))))
@@ -94,9 +71,6 @@ extension TestResult : Testable {
 }
 
 extension Bool : Testable {
-	/// `Bool`ean values are trivially exhaustive.
-	public var exhaustive : Bool { return true }
-
 	/// Returns a property that evaluates to a test success if the receiver is
 	/// `true`, else returns a property that evaluates to a test failure.
 	public var property : Property {

--- a/Sources/WitnessedArbitrary.swift
+++ b/Sources/WitnessedArbitrary.swift
@@ -9,15 +9,7 @@
 extension Array where Element : Arbitrary {
 	/// Returns a generator of `Array`s of arbitrary `Element`s.
 	public static var arbitrary : Gen<Array<Element>> {
-		return Gen.sized { n in
-			return Gen<Int>.choose((0, n)).flatMap { k in
-				if k == 0 {
-					return Gen.pure([])
-				}
-
-				return sequence((0...k).map { _ in Element.arbitrary })
-			}
-		}
+		return Element.arbitrary.proliferate
 	}
 
 	/// The default shrinking function for `Array`s of arbitrary `Element`s.

--- a/Tests/GenSpec.swift
+++ b/Tests/GenSpec.swift
@@ -22,6 +22,25 @@ class GenSpec : XCTestCase {
 			}
 		}
 
+		property("Gen.choose stays in bounds") <- forAll { (x : Int, y : Int) in 
+			let (mx, mn) = (Swift.max(x, y), Swift.min(x, y))
+			return forAll(Gen<Int>.choose((mn, mx))) { n in
+				return mn <= n && n <= mx
+			}
+		}
+
+		property("Gen<Int>.chooseAny stays in bounds") <- forAll(Gen<Int>.chooseAny()) { x in Int.min <= x && x <= Int.max }
+		property("Gen<Int8>.chooseAny stays in bounds") <- forAll(Gen<Int8>.chooseAny()) { x in Int8.min <= x && x <= Int8.max }
+		property("Gen<Int16>.chooseAny stays in bounds") <- forAll(Gen<Int16>.chooseAny()) { x in Int16.min <= x && x <= Int16.max }
+		property("Gen<Int32>.chooseAny stays in bounds") <- forAll(Gen<Int32>.chooseAny()) { x in Int32.min <= x && x <= Int32.max }
+		property("Gen<Int64>.chooseAny stays in bounds") <- forAll(Gen<Int64>.chooseAny()) { x in Int64.min <= x && x <= Int64.max }
+
+		property("Gen<UInt>.chooseAny stays in bounds") <- forAll(Gen<UInt>.chooseAny()) { x in UInt.min <= x && x <= UInt.max }
+		property("Gen<UInt8>.chooseAny stays in bounds") <- forAll(Gen<UInt8>.chooseAny()) { x in UInt8.min <= x && x <= UInt8.max }
+		property("Gen<UInt16>.chooseAny stays in bounds") <- forAll(Gen<UInt16>.chooseAny()) { x in UInt16.min <= x && x <= UInt16.max }
+		property("Gen<UInt32>.chooseAny stays in bounds") <- forAll(Gen<UInt32>.chooseAny()) { x in UInt32.min <= x && x <= UInt32.max }
+		property("Gen<UInt64>.chooseAny stays in bounds") <- forAll(Gen<UInt64>.chooseAny()) { x in UInt64.min <= x && x <= UInt64.max }
+
 		property("Gen.frequency with N arguments behaves") <- forAll(Gen<Int>.choose((1, 1000))) { n in
 			return forAll(Gen.frequency(Array(repeating: (1, Gen.pure(0)), count: n))) { $0 == 0 }
 		}

--- a/Tests/GenSpec.swift
+++ b/Tests/GenSpec.swift
@@ -15,7 +15,7 @@ class GenSpec : XCTestCase {
 			let g = Gen.frequency([
 				(10, Gen.pure(0)),
 				(5, Gen.pure(1)),
-				])
+			])
 
 			return forAll(g) { (i : Int) in
 				return true
@@ -107,8 +107,8 @@ class GenSpec : XCTestCase {
 			return forAll(Gen<Int>.sized { xx in
 				n = xx
 				return Int.arbitrary
-				}.resize(n)) { (x : Int) in
-					return x <= n
+			}.resize(n)) { (x : Int) in
+				return x <= n
 			}
 		}
 

--- a/Tests/PropertySpec.swift
+++ b/Tests/PropertySpec.swift
@@ -49,9 +49,27 @@ class PropertySpec : XCTestCase {
 				let b = bomb! // Will explode if we test more than once
 				bomb = nil
 				return b == n
-				}.once
+			}.once
 		}
 
+		property("Again undoes once") <- forAll { (n : Int) in
+			var counter : Int = 0
+			quickCheck(forAll { (_ : Int) in
+				counter += 1
+				return true
+			}.once.again)
+			return counter > 1
+		}
+		
+		property("Once undoes again") <- forAll { (n : Int) in
+			var bomb : Optional<Int> = .some(n)
+			return forAll { (_ : Int) in
+				let b = bomb! // Will explode if we test more than once
+				bomb = nil
+				return b == n
+			}.again.once
+		}
+		
 		property("Conjamb randomly picks from multiple generators") <- forAll { (n : Int, m : Int, o : Int) in
 			return conjamb({
 				return true <?> "picked 1"


### PR DESCRIPTION
Adds some missing features so we can catch up to QuickCheck

- Removes `exhaustive`.  Use `once`.
- Simplifies `Array<T>`'s `Arbitrary` and `WitnessedArbitrary` instances.
- Adds the `again` combinator to complement `once`.
- Adds `Gen.chooseAny` for easy generator construction of `LatticeType`s.
- Fixes a crash that can occur if `UInt64`'s upper bounds are used with a `RandomType` combinator.