### PR TITLE
Disbale bitcode for Switch-Check-iOS Target

### DIFF
--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -1027,6 +1027,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -1064,6 +1065,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",


### PR DESCRIPTION
What's in this pull request?
============================

Disable bitcode for the iOS target.

Why merge this pull request?
============================

`SwiftCheck` fails to build with Carthage as `XCTest` is not built with bitcode. Other testing frameworks have also disabled bit code, see Quick PR https://github.com/Quick/Quick/pull/342

What's worth discussing about this pull request?
================================================

n/a

What downsides are there to merging this pull request?
======================================================

There are no disadvantages to this change. Testing frameworks should not be shipped to the app store and so are not in need of the benefits that come with bit code / app thinning.