### PR TITLE
fixed Travis iOS_DEVICE_NAME target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - xcodebuild test -scheme SwiftCheck | xcpretty -c
         # -- Start iOS --
         # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
-        - iOS_DEVICE_NAME="iPad Pro (12.9 inch)"
+        - iOS_DEVICE_NAME="iPad Pro (12.9-inch)"
         - iOS_RUNTIME_VERSION="10.0"
         # Get simulator identifier for desired device/runtime pair
         - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")


### PR DESCRIPTION
What's in this pull request?
============================

A change in `iOS_DEVICE_NAME` for Travis configuration: the constant is now `iPad Pro (12.9-inch)`

Why merge this pull request?
============================

Without this, the Travis build fails because it doesn't recognize the `iPad Pro (12.9 inch)` target (without a dash).

What's worth discussing about this pull request?
================================================

Are there other things on the Travis configuration that should be changed? I'm not sure about that.

What downsides are there to merging this pull request?
======================================================
