### PR TITLE
Resolves #235: xcode 9 beta 5 deprecation fixes: truncatingIfNeeded + string slicing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ matrix:
       before_install:
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/development/ubuntu1404/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04.tar.gz
-        - tar xzf swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04/usr/bin:"${PATH}"
+        - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04.tar.gz
+        - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-08-04-a-ubuntu14.04/usr/bin:"${PATH}"
         - pushd Utilities
         - ./compile.sh
         - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ matrix:
       before_install:
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/swift-4.0-branch/ubuntu1404/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-06-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-06-a-ubuntu14.04.tar.gz
-        - tar xzf swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-06-a-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-07-06-a-ubuntu14.04/usr/bin:"${PATH}"
+        - wget https://swift.org/builds/development/ubuntu1404/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04.tar.gz
+        - tar xzf swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-DEVELOPMENT-SNAPSHOT-2017-08-03-a-ubuntu14.04/usr/bin:"${PATH}"
         - pushd Utilities
         - ./compile.sh
         - popd

--- a/Sources/SwiftCheck/Arbitrary.swift
+++ b/Sources/SwiftCheck/Arbitrary.swift
@@ -107,7 +107,7 @@ extension Int8 : Arbitrary {
 	/// Returns a generator of `Int8` values.
 	public static var arbitrary : Gen<Int8> {
 		return Gen.sized { n in
-			return Gen<Int8>.choose((Int8(extendingOrTruncating: -n), Int8(extendingOrTruncating: n)))
+			return Gen<Int8>.choose((Int8(truncatingIfNeeded: -n), Int8(truncatingIfNeeded: n)))
 		}
 	}
 
@@ -121,7 +121,7 @@ extension Int16 : Arbitrary {
 	/// Returns a generator of `Int16` values.
 	public static var arbitrary : Gen<Int16> {
 		return Gen.sized { n in
-			return Gen<Int16>.choose((Int16(extendingOrTruncating: -n), Int16(extendingOrTruncating: n)))
+			return Gen<Int16>.choose((Int16(truncatingIfNeeded: -n), Int16(truncatingIfNeeded: n)))
 		}
 	}
 
@@ -135,7 +135,7 @@ extension Int32 : Arbitrary {
 	/// Returns a generator of `Int32` values.
 	public static var arbitrary : Gen<Int32> {
 		return Gen.sized { n in
-			return Gen<Int32>.choose((Int32(extendingOrTruncating: -n), Int32(extendingOrTruncating: n)))
+			return Gen<Int32>.choose((Int32(truncatingIfNeeded: -n), Int32(truncatingIfNeeded: n)))
 		}
 	}
 
@@ -175,7 +175,7 @@ extension UInt8 : Arbitrary {
 	/// Returns a generator of `UInt8` values.
 	public static var arbitrary : Gen<UInt8> {
 		return Gen.sized { n in
-			return Gen.sized { n in Gen<UInt8>.choose((0, UInt8(extendingOrTruncating: n))) }
+			return Gen.sized { n in Gen<UInt8>.choose((0, UInt8(truncatingIfNeeded: n))) }
 		}
 	}
 
@@ -188,7 +188,7 @@ extension UInt8 : Arbitrary {
 extension UInt16 : Arbitrary {
 	/// Returns a generator of `UInt16` values.
 	public static var arbitrary : Gen<UInt16> {
-		return Gen.sized { n in Gen<UInt16>.choose((0, UInt16(extendingOrTruncating: n))) }
+		return Gen.sized { n in Gen<UInt16>.choose((0, UInt16(truncatingIfNeeded: n))) }
 	}
 
 	/// The default shrinking function for `UInt16` values.
@@ -200,7 +200,7 @@ extension UInt16 : Arbitrary {
 extension UInt32 : Arbitrary {
 	/// Returns a generator of `UInt32` values.
 	public static var arbitrary : Gen<UInt32> {
-		return Gen.sized { n in Gen<UInt32>.choose((0, UInt32(extendingOrTruncating: n))) }
+		return Gen.sized { n in Gen<UInt32>.choose((0, UInt32(truncatingIfNeeded: n))) }
 	}
 
 	/// The default shrinking function for `UInt32` values.

--- a/Sources/SwiftCheck/CoArbitrary.swift
+++ b/Sources/SwiftCheck/CoArbitrary.swift
@@ -71,7 +71,7 @@ extension String : CoArbitrary {
 		}
 		return comp(
 			Character.coarbitrary(x[x.startIndex]), 
-			String.coarbitrary(x.substring(with: x.characters.index(after: x.startIndex)..<x.endIndex))
+			String.coarbitrary(String(x[x.characters.index(after: x.startIndex)..<x.endIndex]))
 		)
 	}
 }

--- a/Sources/SwiftCheck/Random.swift
+++ b/Sources/SwiftCheck/Random.swift
@@ -154,7 +154,7 @@ extension Int : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (Int, Int), gen : G) -> (Int, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
-		return (Int(extendingOrTruncating: bb), gg)
+		return (Int(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -163,7 +163,7 @@ extension Int8 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (Int8, Int8), gen : G) -> (Int8, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
-		return (Int8(extendingOrTruncating: bb), gg)
+		return (Int8(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -172,7 +172,7 @@ extension Int16 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (Int16, Int16), gen : G) -> (Int16, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
-		return (Int16(extendingOrTruncating: bb), gg)
+		return (Int16(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -181,7 +181,7 @@ extension Int32 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (Int32, Int32), gen : G) -> (Int32, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = Int64.randomInRange((Int64(minl), Int64(maxl)), gen: gen)
-		return (Int32(extendingOrTruncating: bb), gg)
+		return (Int32(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -228,7 +228,7 @@ extension UInt : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt, UInt), gen : G) -> (UInt, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
-		return (UInt(extendingOrTruncating: bb), gg)
+		return (UInt(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -237,7 +237,7 @@ extension UInt8 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt8, UInt8), gen : G) -> (UInt8, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
-		return (UInt8(extendingOrTruncating: bb), gg)
+		return (UInt8(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -246,7 +246,7 @@ extension UInt16 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt16, UInt16), gen : G) -> (UInt16, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
-		return (UInt16(extendingOrTruncating: bb), gg)
+		return (UInt16(truncatingIfNeeded: bb), gg)
 	}
 }
 
@@ -255,7 +255,7 @@ extension UInt32 : RandomType {
 	public static func randomInRange<G : RandomGeneneratorType>(_ range : (UInt32, UInt32), gen : G) -> (UInt32, G) {
 		let (minl, maxl) = range
 		let (bb, gg) = UInt64.randomInRange((UInt64(minl), UInt64(maxl)), gen: gen)
-		return (UInt32(extendingOrTruncating: bb), gg)
+		return (UInt32(truncatingIfNeeded: bb), gg)
 	}
 }
 


### PR DESCRIPTION
What's in this pull request?
============================

Some small updates to adjust to deprecations between Xcode 9 Beta 4 and Beta 5.

Namely:

  - `init(extendingOrTruncating:)` has been renamed `init(truncatingIfNeeded:)`
  - `myString.subscript(with:myRange)` is now `String(myString[myRange])`

Why merge this pull request?
============================

Resolves #235. Necessary for Xcode 9 Beta 5 support on the `swift-develop` branch.

What's worth discussing about this pull request?
================================================

This is a pretty straightforward change.

What downsides are there to merging this pull request?
======================================================

None that I am aware of.
