### PR TITLE
Migate and update to Swift 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: osx
       language: objective-c
-      osx_image: xcode8.3
+      osx_image: xcode9
       before_install:
         - git submodule update --init --recursive
         - pushd Utilities
@@ -16,7 +16,7 @@ matrix:
         - carthage build --no-skip-current
     - os: osx
       language: objective-c
-      osx_image: xcode8.3
+      osx_image: xcode9
       before_install:
         - git submodule update --init --recursive
         - pushd Utilities
@@ -45,9 +45,9 @@ matrix:
       before_install:
         - git submodule update --init --recursive
         - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-        - wget https://swift.org/builds/swift-3.1-release/ubuntu1404/swift-3.1-RELEASE/swift-3.1-RELEASE-ubuntu14.04.tar.gz
-        - tar xzf swift-3.1-RELEASE-ubuntu14.04.tar.gz
-        - export PATH=${PWD}/swift-3.1-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
+        - wget https://swift.org/builds/swift-4.0-release/ubuntu1404/swift-4.0-RELEASE/swift-4.0-RELEASE-ubuntu14.04.tar.gz
+        - tar xzf swift-4.0-RELEASE-ubuntu14.04.tar.gz
+        - export PATH=${PWD}/swift-4.0-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
         - pushd Utilities
         - ./compile.sh
         - popd

--- a/Sources/Arbitrary.swift
+++ b/Sources/Arbitrary.swift
@@ -61,7 +61,7 @@ extension Arbitrary {
 	}
 }
 
-extension Integer {
+extension FixedWidthInteger {
 	/// Shrinks any `IntegerType`.
 	public var shrinkIntegral : [Self] {
 		return unfoldr({ i in
@@ -70,7 +70,7 @@ extension Integer {
 			}
 			let n = i / 2
 			return .some((n, n))
-		}, initial: self < 0 ? (Self.multiplyWithOverflow(self, -1).0) : self)
+		}, initial: self < 0 ? self.multipliedReportingOverflow(by: -1).partialValue : self)
 	}
 }
 

--- a/Sources/Gen.swift
+++ b/Sources/Gen.swift
@@ -44,11 +44,22 @@ public struct Gen<A> {
 	/// collection and produces only that value.
 	///
 	/// The input collection is required to be non-empty.
-	public static func fromElements<S : Collection>(of xs : S) -> Gen<S._Element>
-		where S.Index : Comparable & RandomType
+	public static func fromElements<S : Collection>(of xs : S) -> Gen<S.Element>
+		where S.Index : RandomType
 	{
 		return Gen.fromElements(in: xs.startIndex...xs.index(xs.endIndex, offsetBy: -1)).map { i in
 			return xs[i]
+		}
+	}
+
+	/// Constructs a Generator that selects a random value from the given
+	/// collection and produces only that value.
+	///
+	/// The input collection is required to be non-empty.
+	public static func fromElements<T>(of xs : Set<T>) -> Gen<T> {
+		precondition(!xs.isEmpty)
+		return Gen.fromElements(in: 0...xs.distance(from: xs.startIndex, to: xs.endIndex)-1).map { i in
+			return xs[xs.index(xs.startIndex, offsetBy: i)]
 		}
 	}
 
@@ -120,7 +131,7 @@ public struct Gen<A> {
 	/// If control over the distribution of generators is needed, see
 	/// `Gen.frequency` or `Gen.weighted`.
 	public static func one<S : BidirectionalCollection>(of gs : S) -> Gen<A>
-		where S.Iterator.Element == Gen<A>, S.Index : RandomType & Comparable
+		where S.Iterator.Element == Gen<A>, S.Index : RandomType
 	{
 		assert(gs.count != 0, "oneOf used with empty list")
 
@@ -277,8 +288,8 @@ extension Gen {
 
 extension Gen {
 	@available(*, unavailable, renamed: "fromElements(of:)")
-	public static func fromElementsOf<S : Collection>(_ xs : S) -> Gen<S._Element>
-		where S.Index : Comparable & RandomType
+	public static func fromElementsOf<S : Collection>(_ xs : S) -> Gen<S.Element>
+		where S.Index : RandomType
 	{
 		return Gen.fromElements(of: xs)
 	}
@@ -302,7 +313,7 @@ extension Gen {
 
 	@available(*, unavailable, renamed: "one(of:)")
 	public static func oneOf<S : BidirectionalCollection>(_ gs : S) -> Gen<A>
-		where S.Iterator.Element == Gen<A>, S.Index : RandomType & Comparable
+		where S.Iterator.Element == Gen<A>, S.Index : RandomType
 	{
 		return Gen.one(of: gs)
 	}

--- a/Sources/Lattice.swift
+++ b/Sources/Lattice.swift
@@ -79,12 +79,12 @@ extension Double : LatticeType {
 }
 
 extension AnyIndex : LatticeType {
-	/// The lower limit of the `AnyForwardIndex` type.
+	/// The lower limit of the `AnyIndex` type.
 	public static var min : AnyIndex {
 		return AnyIndex(Int64.min)
 	}
 
-	/// The upper limit of the `AnyForwardIndex` type.
+	/// The upper limit of the `AnyIndex` type.
 	public static var max : AnyIndex {
 		return AnyIndex(Int64.max)
 	}

--- a/Sources/Modifiers.swift
+++ b/Sources/Modifiers.swift
@@ -398,7 +398,7 @@ extension IsoOf : CustomReflectable {
 
 /// By default, SwiftCheck generates values drawn from a small range. `Large`
 /// gives you values drawn from the entire range instead.
-public struct Large<A : RandomType & LatticeType & Integer> : Arbitrary {
+public struct Large<A : RandomType & LatticeType & FixedWidthInteger> : Arbitrary {
 	/// Retrieves the underlying large value.
 	public let getLarge : A
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -597,7 +597,7 @@ private func protectResult(_ r : @escaping () throws -> TestResult) -> (() -> Te
 	return { protect(exception("Exception"), x: r) }
 }
 
-internal func unionWith<K : Hashable, V>(_ f : (V, V) -> V, l : Dictionary<K, V>, r : Dictionary<K, V>) -> Dictionary<K, V> {
+internal func unionWith<K, V>(_ f : (V, V) -> V, l : Dictionary<K, V>, r : Dictionary<K, V>) -> Dictionary<K, V> {
 	var map = l
 	r.forEach { (k, v) in
 		if let val = map.updateValue(v, forKey: k) {
@@ -607,7 +607,7 @@ internal func unionWith<K : Hashable, V>(_ f : (V, V) -> V, l : Dictionary<K, V>
 	return map
 }
 
-private func insertWith<K : Hashable, V>(_ f : (V, V) -> V, k : K, v : V, m : Dictionary<K, V>) -> Dictionary<K, V> {
+private func insertWith<K, V>(_ f : (V, V) -> V, k : K, v : V, m : Dictionary<K, V>) -> Dictionary<K, V> {
 	var res = m
 	let oldV = res[k]
 	if let existV = oldV {

--- a/Sources/WitnessedArbitrary.swift
+++ b/Sources/WitnessedArbitrary.swift
@@ -192,9 +192,7 @@ extension Dictionary where Key : Arbitrary, Value : Arbitrary {
 	/// The default shrinking function for `Dictionary`s of arbitrary `Key`s and
 	/// `Value`s.
 	public static func shrink(_ d : Dictionary<Key, Value>) -> [Dictionary<Key, Value>] {
-		return d.map { Dictionary(zip(Key.shrink($0), Value.shrink($1)).map({ (k, v) -> (key: Key, value: Value) in
-			(key: k, value: v)
-		})) }
+		return d.map { t in Dictionary(zip(Key.shrink(t.key), Value.shrink(t.value)), uniquingKeysWith: { (_, v) in v }) }
 	}
 }
 
@@ -205,7 +203,7 @@ extension EmptyCollection : Arbitrary {
 	}
 }
 
-extension Range where Bound : Comparable & Arbitrary {
+extension Range where Bound : Arbitrary {
 	/// Returns a generator of `HalfOpenInterval`s of arbitrary `Bound`s.
 	public static var arbitrary : Gen<Range<Bound>> {
 		return Bound.arbitrary.flatMap { l in
@@ -221,14 +219,14 @@ extension Range where Bound : Comparable & Arbitrary {
 	}
 }
 
-extension LazyCollection where Base : Collection & Arbitrary, Base.Index : Comparable {
+extension LazyCollection where Base : Arbitrary {
 	/// Returns a generator of `LazyCollection`s of arbitrary `Base`s.
 	public static var arbitrary : Gen<LazyCollection<Base>> {
 		return LazyCollection<Base>.arbitrary
 	}
 }
 
-extension LazySequence where Base : Sequence & Arbitrary {
+extension LazySequence where Base : Arbitrary {
 	/// Returns a generator of `LazySequence`s of arbitrary `Base`s.
 	public static var arbitrary : Gen<LazySequence<Base>> {
 		return LazySequence<Base>.arbitrary
@@ -259,7 +257,7 @@ extension Repeated : WitnessedArbitrary {
 	}
 }
 
-extension Set where Element : Arbitrary & Hashable {
+extension Set where Element : Arbitrary {
 	/// Returns a generator of `Set`s of arbitrary `Element`s.
 	public static var arbitrary : Gen<Set<Element>> {
 		return Gen.sized { n in

--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -808,6 +808,7 @@
 				PRODUCT_NAME = SwiftCheck;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -840,6 +841,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -860,6 +862,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -877,6 +880,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -999,6 +1003,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -1031,6 +1036,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -1053,6 +1059,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -1072,6 +1079,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -1105,6 +1113,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1138,6 +1147,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
@@ -1166,6 +1176,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -1186,6 +1197,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/Tests/SwiftCheckTests/BooleanIdentitySpec.swift
+++ b/Tests/SwiftCheckTests/BooleanIdentitySpec.swift
@@ -9,6 +9,7 @@
 import SwiftCheck
 import XCTest
 
+
 class BooleanIdentitySpec : XCTestCase {
 	func testAll() {
 		XCTAssert(fileCheckOutput {

--- a/Tests/SwiftCheckTests/PathSpec.swift
+++ b/Tests/SwiftCheckTests/PathSpec.swift
@@ -52,13 +52,13 @@ struct Extremal<A : Arbitrary & LatticeType> : Arbitrary {
 }
 
 class PathSpec : XCTestCase {
-	private static func smallProp<A : Integer & Arbitrary>(_ pth : Path<A>) -> Bool {
+	private static func smallProp<A : Integer>(_ pth : Path<A>) -> Bool {
 		return path({ x in
 			return (x >= -100 || -100 >= 0) && x <= 100
 		}, pth)
 	}
 
-	private static func largeProp<A : Integer & Arbitrary>(_ pth : Path<A>) -> Property {
+	private static func largeProp<A : Integer>(_ pth : Path<A>) -> Property {
 		return somePath({ x in
 			return (x < -1000000 || x > 1000000)
 		}, pth)

--- a/Tutorial.playground/Contents.swift
+++ b/Tutorial.playground/Contents.swift
@@ -292,7 +292,7 @@ emailGen.generate
 //: Library, but we also use them in more benign ways too.  For example, we can write a modifier type
 //: that only generates positive numbers:
 
-public struct ArbitraryPositive<A : Arbitrary & SignedNumber> : Arbitrary {
+public struct ArbitraryPositive<A : Arbitrary & Comparable & SignedNumeric> : Arbitrary {
 	public let getPositive : A
 
 	public init(_ pos : A) { self.getPositive = pos }
@@ -342,7 +342,7 @@ property("The reverse of the reverse of an array is that array") <- forAll { (xs
 //                                           v                    v
 property("filter behaves") <- forAll { (xs : ArrayOf<Int>, pred : ArrowOf<Int, Bool>) in
 	let f = pred.getArrow
-	return xs.getArray.filter(f).reduce(true, { $0.0 && f($0.1) })
+	return xs.getArray.filter(f).reduce(true, { $0 && f($1) })
 	// ^ This property says that if we filter an array then apply the predicate
 	//   to all its elements, then they should all respond with `true`.
 }


### PR DESCRIPTION
I anticipate this being the last version of Swift 3 that we support before migrating everything to Swift 4.

As Travis has committed to supporting Xcode 9 beta 5, a minor release is currently only blocked on swift.org providing Swift 3.2/4.0 binaries for our Linux build.  I've switched to using a nightly for now.