### PR TITLE
Switch to built-in SWIFT_PACKAGE flag

### DIFF
--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -905,7 +905,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typelift.SwiftCheck-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -925,7 +925,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typelift.SwiftCheck-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1119,7 +1119,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1141,7 +1141,7 @@
 				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1240,7 +1240,7 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1263,7 +1263,7 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "-D XCODE_BUILD";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.codafi.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Templates/CartesianSpec.swift.gyb
+++ b/Templates/CartesianSpec.swift.gyb
@@ -16,7 +16,7 @@ MAX_ARITY = 22
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 import Foundation

--- a/Tests/SwiftCheckTests/BooleanIdentitySpec.swift
+++ b/Tests/SwiftCheckTests/BooleanIdentitySpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/CartesianSpec.swift
+++ b/Tests/SwiftCheckTests/CartesianSpec.swift
@@ -13,7 +13,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 import Foundation

--- a/Tests/SwiftCheckTests/ComplexSpec.swift
+++ b/Tests/SwiftCheckTests/ComplexSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/DiscardSpec.swift
+++ b/Tests/SwiftCheckTests/DiscardSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/FailureSpec.swift
+++ b/Tests/SwiftCheckTests/FailureSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/FormatterSpec.swift
+++ b/Tests/SwiftCheckTests/FormatterSpec.swift
@@ -10,7 +10,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/GenSpec.swift
+++ b/Tests/SwiftCheckTests/GenSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 import Foundation

--- a/Tests/SwiftCheckTests/LambdaSpec.swift
+++ b/Tests/SwiftCheckTests/LambdaSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/ModifierSpec.swift
+++ b/Tests/SwiftCheckTests/ModifierSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/PathSpec.swift
+++ b/Tests/SwiftCheckTests/PathSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/PropertySpec.swift
+++ b/Tests/SwiftCheckTests/PropertySpec.swift
@@ -8,7 +8,7 @@
 
 @testable import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/ReplaySpec.swift
+++ b/Tests/SwiftCheckTests/ReplaySpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/RoseSpec.swift
+++ b/Tests/SwiftCheckTests/RoseSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/ShrinkSpec.swift
+++ b/Tests/SwiftCheckTests/ShrinkSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/SimpleSpec.swift
+++ b/Tests/SwiftCheckTests/SimpleSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 

--- a/Tests/SwiftCheckTests/TestSpec.swift
+++ b/Tests/SwiftCheckTests/TestSpec.swift
@@ -8,7 +8,7 @@
 
 import SwiftCheck
 import XCTest
-#if !XCODE_BUILD
+#if SWIFT_PACKAGE
 import FileCheck
 #endif
 


### PR DESCRIPTION
I *think* this isn't needed, but the CocoaPods and Carthage builds will be the ultimate determiner.