### PR TITLE
Fix random number generation for Float and Double

### DIFF
--- a/Sources/SwiftCheck/Random.swift
+++ b/Sources/SwiftCheck/Random.swift
@@ -298,7 +298,7 @@ extension Float : RandomType {
 	/// Produces a random `Float` value in the range `[Float.min, Float.max]`.
 	public static func random<G : RandomGeneneratorType>(_ rng : G) -> (Float, G) {
 		let (x, rng_) : (Int32, G) = randomBound(rng)
-		let twoto24 = Int32(2) ^ Int32(24)
+		let twoto24: Int32 = 1 << 24
 		let mask24 = twoto24 - 1
 
 		return (Float(mask24 & (x)) / Float(twoto24), rng_)
@@ -320,7 +320,7 @@ extension Double : RandomType {
 	/// Produces a random `Float` value in the range `[Double.min, Double.max]`.
 	public static func random<G : RandomGeneneratorType>(_ rng : G) -> (Double, G) {
 		let (x, rng_) : (Int64, G) = randomBound(rng)
-		let twoto53 = Int64(2) ^ Int64(53)
+		let twoto53: Int64 = 1 << 53
 		let mask53 = twoto53 - 1
 
 		return (Double(mask53 & (x)) / Double(twoto53), rng_)


### PR DESCRIPTION
What's in this pull request?
============================

In `Float.random` and `Double.random` I changed the `^` (bitwise XOR) to `<<` to fix random number generation. I assume the bug comes from Haskell using `^` for exponentiation, see https://hackage.haskell.org/package/random-1.1/docs/src/System-Random.html#line-408 for the Haskell implementation.

Why merge this pull request?
============================

It fixes a bug.

What's worth discussing about this pull request?
================================================

I used an explicit type annotation instead of explicitly constructing `Int64`s from integer literals. Happy to change it if that doesn't match the style of the rest of the code.

What downsides are there to merging this pull request?
======================================================

None that I can think of.
