### PR TITLE
Refactor generic static gen functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ let vowels = Gen.fromElements(of: [ "A", "E", "I", "O", "U" ])
 
 let randomHexValue = Gen<UInt>.choose((0, 15))
 
-let uppers : Gen<Character> = Gen<Character>.fromElements(in: "A"..."Z")
-let lowers : Gen<Character> = Gen<Character>.fromElements(in: "a"..."z")
-let numbers : Gen<Character> = Gen<Character>.fromElements(in: "0"..."9")
+let uppers = Gen<Character>.fromElements(in: "A"..."Z")
+let lowers = Gen<Character>.fromElements(in: "a"..."z")
+let numbers = Gen<Character>.fromElements(in: "0"..."9")
  
 /// This generator will generate `.none` 1/4 of the time and an arbitrary
 /// `.some` 3/4 of the time
@@ -346,4 +346,3 @@ License
 =======
 
 SwiftCheck is released under the MIT license.
-

--- a/Sources/SwiftCheck/Arbitrary.swift
+++ b/Sources/SwiftCheck/Arbitrary.swift
@@ -321,7 +321,7 @@ extension String : Arbitrary {
 extension Character : Arbitrary {
 	/// Returns a generator of `Character` values.
 	public static var arbitrary : Gen<Character> {
-		return Gen<UInt32>.choose((32, 255)).flatMap(comp(Gen<Character>.pure, comp(Character.init, UnicodeScalar.init)))
+		return Gen<UInt8>.choose((32, 255)).flatMap(comp(Gen<Character>.pure, comp(Character.init, UnicodeScalar.init)))
 	}
 
 	/// The default shrinking function for `Character` values.

--- a/Tests/SwiftCheckTests/GenSpec.swift
+++ b/Tests/SwiftCheckTests/GenSpec.swift
@@ -109,13 +109,13 @@ class GenSpec : XCTestCase {
 					return Discard()
 				}
 				let l = Set(xss)
-				return forAll(Gen<[Int]>.fromElements(of: xss)) { l.contains($0) }
+				return forAll(Gen.fromElements(of: xss)) { l.contains($0) }
 			}
 
 			// CHECK-NEXT: *** Passed 100 tests
 			// CHECK-NEXT: .
 			property("Gen.fromElementsOf only generates the elements of the given array") <- forAll { (n1 : Int, n2 : Int) in
-				return forAll(Gen<[Int]>.fromElements(of: [n1, n2])) { $0 == n1 || $0 == n2 }
+				return forAll(Gen.fromElements(of: [n1, n2])) { $0 == n1 || $0 == n2 }
 			}
 
 			// CHECK-NEXT: *** Passed 100 tests
@@ -123,7 +123,7 @@ class GenSpec : XCTestCase {
 			property("Gen.fromElementsIn only generates the elements of the given interval") <- forAll { (n1 : Int, n2 : Int) in
 				return (n1 < n2) ==> {
 					let interval = n1...n2
-					return forAll(Gen<[Int]>.fromElements(in: n1...n2)) { interval.contains($0) }
+					return forAll(Gen.fromElements(in: n1...n2)) { interval.contains($0) }
 				}
 			}
 
@@ -131,7 +131,7 @@ class GenSpec : XCTestCase {
 			// CHECK-NEXT: .
 			property("Gen.fromInitialSegmentsOf produces only prefixes of the generated array") <- forAll { (xs : Array<Int>) in
 				return !xs.isEmpty ==> {
-					return forAllNoShrink(Gen<[Int]>.fromInitialSegments(of: xs)) { (ys : Array<Int>) in
+					return forAllNoShrink(Gen.fromInitialSegments(of: xs)) { (ys : Array<Int>) in
 						return xs.starts(with: ys)
 					}
 				}
@@ -140,7 +140,7 @@ class GenSpec : XCTestCase {
 			// CHECK-NEXT: *** Passed 100 tests
 			// CHECK-NEXT: .
 			property("Gen.fromShufflingElementsOf produces only permutations of the generated array") <- forAll { (xs : Array<Int>) in
-				return forAllNoShrink(Gen<[Int]>.fromShufflingElements(of: xs)) { (ys : Array<Int>) in
+				return forAllNoShrink(Gen.fromShufflingElements(of: xs)) { (ys : Array<Int>) in
 					return (xs.count == ys.count) ^&&^ (xs.sorted() == ys.sorted())
 				}
 			}
@@ -355,8 +355,8 @@ class GenSpec : XCTestCase {
 	func testLaws() {
 		XCTAssert(fileCheckOutput(withPrefixes: ["LAW"]) {
 			/// Turns out Gen is a really sketchy monad because of the underlying randomness.
-			let lawfulGen = Gen<Gen<Int>>.fromElements(of: (0...500).map(Gen.pure))
-			let lawfulArrowGen = Gen<Gen<ArrowOf<Int, Int>>>.fromElements(of: ArrowOf<Int, Int>.arbitrary.proliferate(withSize: 10).generate.map(Gen.pure))
+			let lawfulGen = Gen.fromElements(of: (0...500).map(Gen.pure))
+			let lawfulArrowGen = Gen.fromElements(of: ArrowOf<Int, Int>.arbitrary.proliferate(withSize: 10).generate.map(Gen.pure))
 
 			// LAW: *** Passed 100 tests
 			// LAW-NEXT: .


### PR DESCRIPTION
What's in this pull request?
============================

This pull requests moves static functions with type constraints on `Gen` into constrained extensions.


Why merge this pull request?
============================

This fixes some issues with calls to `fromElements` and `choose`.
Before this PR the following code did not return a `Gen<UInt>`, but a `Gen<Int>`.

```swift
let randomHexValue = Gen<UInt>.choose((0, 15))
```

In addition, it simplifies call sites by not requiring explicit type annotations:

```swift
let uppers : Gen<Character> = Gen<Character>.fromElements(in: "A"..."Z")
```

can now be written as

```swift
let uppers = Gen<Character>.fromElements(in: "A"..."Z")
```

What's worth discussing about this pull request?
================================================

I might have missed the reason why those functions were not in extensions.

What downsides are there to merging this pull request?
======================================================

As far as I can tell, all refactored functions can still be called with the exact same types.
