### PR TITLE
Refactor zip to ensure type consistency

### DIFF
--- a/Sources/SwiftCheck/Cartesian.swift
+++ b/Sources/SwiftCheck/Cartesian.swift
@@ -18,10 +18,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga1: A generator of values of type `A1`.
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
-	public static func zip<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>) -> Gen<(A1, A2, A3)> {
-		return Gen
+	public static func zip<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>) -> Gen<(A1, A2, A3)> where A == (A1, A2, A3) {
+		return Gen<((A1, A2), A3)>
 			.zip(
-				.zip(ga1, ga2),
+				Gen<(A1, A2)>.zip(ga1, ga2),
 				ga3
 			).map { t in
 				(t.0.0, t.0.1, t.1)
@@ -34,8 +34,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga1: A generator of values of type `A1`.
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
-	public static func map<A1, A2, A3, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform : @escaping (A1, A2, A3) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3).map({ t in transform(t.0, t.1, t.2) })
+	public static func map<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform : @escaping (A1, A2, A3) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3)>.zip(ga1, ga2, ga3).map({ t in transform(t.0, t.1, t.2) })
 	}
 
 	/// Zips together 4 generators into a generator of 4-tuples.
@@ -44,10 +44,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
-	public static func zip<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>) -> Gen<(A1, A2, A3, A4)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>) -> Gen<(A1, A2, A3, A4)> where A == (A1, A2, A3, A4) {
+		return Gen<((A1, A2, A3), A4)>
 			.zip(
-				.zip(ga1, ga2, ga3),
+				Gen<(A1, A2, A3)>.zip(ga1, ga2, ga3),
 				ga4
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.1)
@@ -61,8 +61,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
-	public static func map<A1, A2, A3, A4, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform : @escaping (A1, A2, A3, A4) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4).map({ t in transform(t.0, t.1, t.2, t.3) })
+	public static func map<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform : @escaping (A1, A2, A3, A4) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4)>.zip(ga1, ga2, ga3, ga4).map({ t in transform(t.0, t.1, t.2, t.3) })
 	}
 
 	/// Zips together 5 generators into a generator of 5-tuples.
@@ -72,10 +72,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
-	public static func zip<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>) -> Gen<(A1, A2, A3, A4, A5)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>) -> Gen<(A1, A2, A3, A4, A5)> where A == (A1, A2, A3, A4, A5) {
+		return Gen<((A1, A2, A3, A4), A5)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4),
+				Gen<(A1, A2, A3, A4)>.zip(ga1, ga2, ga3, ga4),
 				ga5
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.1)
@@ -90,8 +90,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
-	public static func map<A1, A2, A3, A4, A5, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, transform : @escaping (A1, A2, A3, A4, A5) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5).map({ t in transform(t.0, t.1, t.2, t.3, t.4) })
+	public static func map<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, transform : @escaping (A1, A2, A3, A4, A5) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5)>.zip(ga1, ga2, ga3, ga4, ga5).map({ t in transform(t.0, t.1, t.2, t.3, t.4) })
 	}
 
 	/// Zips together 6 generators into a generator of 6-tuples.
@@ -102,10 +102,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
-	public static func zip<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>) -> Gen<(A1, A2, A3, A4, A5, A6)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>) -> Gen<(A1, A2, A3, A4, A5, A6)> where A == (A1, A2, A3, A4, A5, A6) {
+		return Gen<((A1, A2, A3, A4, A5), A6)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5),
+				Gen<(A1, A2, A3, A4, A5)>.zip(ga1, ga2, ga3, ga4, ga5),
 				ga6
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.1)
@@ -121,8 +121,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
-	public static func map<A1, A2, A3, A4, A5, A6, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform : @escaping (A1, A2, A3, A4, A5, A6) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5) })
+	public static func map<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform : @escaping (A1, A2, A3, A4, A5, A6) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6)>.zip(ga1, ga2, ga3, ga4, ga5, ga6).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5) })
 	}
 
 	/// Zips together 7 generators into a generator of 7-tuples.
@@ -134,10 +134,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>) -> Gen<(A1, A2, A3, A4, A5, A6, A7)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>) -> Gen<(A1, A2, A3, A4, A5, A6, A7)> where A == (A1, A2, A3, A4, A5, A6, A7) {
+		return Gen<((A1, A2, A3, A4, A5, A6), A7)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6),
+				Gen<(A1, A2, A3, A4, A5, A6)>.zip(ga1, ga2, ga3, ga4, ga5, ga6),
 				ga7
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.1)
@@ -154,8 +154,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6) })
 	}
 
 	/// Zips together 8 generators into a generator of 8-tuples.
@@ -168,10 +168,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8)> where A == (A1, A2, A3, A4, A5, A6, A7, A8) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7), A8)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7),
+				Gen<(A1, A2, A3, A4, A5, A6, A7)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7),
 				ga8
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.1)
@@ -189,8 +189,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7) })
 	}
 
 	/// Zips together 9 generators into a generator of 9-tuples.
@@ -204,10 +204,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8), A9)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8),
 				ga9
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.1)
@@ -226,8 +226,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8) })
 	}
 
 	/// Zips together 10 generators into a generator of 10-tuples.
@@ -242,10 +242,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9), A10)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9),
 				ga10
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.1)
@@ -265,8 +265,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9) })
 	}
 
 	/// Zips together 11 generators into a generator of 11-tuples.
@@ -282,10 +282,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10), A11)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10),
 				ga11
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.1)
@@ -306,8 +306,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10) })
 	}
 
 	/// Zips together 12 generators into a generator of 12-tuples.
@@ -324,10 +324,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11), A12)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11),
 				ga12
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.1)
@@ -349,8 +349,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11) })
 	}
 
 	/// Zips together 13 generators into a generator of 13-tuples.
@@ -368,10 +368,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12), A13)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12),
 				ga13
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.1)
@@ -394,8 +394,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12) })
 	}
 
 	/// Zips together 14 generators into a generator of 14-tuples.
@@ -414,10 +414,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13), A14)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13),
 				ga14
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.1)
@@ -441,8 +441,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13) })
 	}
 
 	/// Zips together 15 generators into a generator of 15-tuples.
@@ -462,10 +462,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14), A15)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14),
 				ga15
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.1)
@@ -490,8 +490,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14) })
 	}
 
 	/// Zips together 16 generators into a generator of 16-tuples.
@@ -512,10 +512,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15), A16)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15),
 				ga16
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.1)
@@ -541,8 +541,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15) })
 	}
 
 	/// Zips together 17 generators into a generator of 17-tuples.
@@ -564,10 +564,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16), A17)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16),
 				ga17
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.1)
@@ -594,8 +594,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16) })
 	}
 
 	/// Zips together 18 generators into a generator of 18-tuples.
@@ -618,10 +618,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17), A18)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17),
 				ga18
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.0.16, t.1)
@@ -649,8 +649,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17) })
 	}
 
 	/// Zips together 19 generators into a generator of 19-tuples.
@@ -674,10 +674,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18), A19)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18),
 				ga19
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.0.16, t.0.17, t.1)
@@ -706,8 +706,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18) })
 	}
 
 	/// Zips together 20 generators into a generator of 20-tuples.
@@ -732,10 +732,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19), A20)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19),
 				ga20
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.0.16, t.0.17, t.0.18, t.1)
@@ -765,8 +765,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19) })
 	}
 
 	/// Zips together 21 generators into a generator of 21-tuples.
@@ -792,10 +792,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20), A21)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20),
 				ga21
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.0.16, t.0.17, t.0.18, t.0.19, t.1)
@@ -826,8 +826,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20) })
 	}
 
 	/// Zips together 22 generators into a generator of 22-tuples.
@@ -854,10 +854,10 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
 	/// - parameter ga22: A generator of values of type `A22`.
-	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)> {
-		return Gen
+	public static func zip<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>) -> Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)> where A == (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) {
+		return Gen<((A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21), A22)>
 			.zip(
-				.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21),
+				Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21),
 				ga22
 			).map { t in
 				(t.0.0, t.0.1, t.0.2, t.0.3, t.0.4, t.0.5, t.0.6, t.0.7, t.0.8, t.0.9, t.0.10, t.0.11, t.0.12, t.0.13, t.0.14, t.0.15, t.0.16, t.0.17, t.0.18, t.0.19, t.0.20, t.1)
@@ -889,8 +889,8 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
 	/// - parameter ga22: A generator of values of type `A22`.
-	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) -> R) -> Gen<R> {
-		return zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20, t.21) })
+	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20, t.21) })
 	}
 
 }

--- a/Sources/SwiftCheck/Cartesian.swift
+++ b/Sources/SwiftCheck/Cartesian.swift
@@ -36,7 +36,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga3: A generator of values of type `A3`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform : @escaping (A1, A2, A3) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3)>.zip(ga1, ga2, ga3).map({ t in transform(t.0, t.1, t.2) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -74,7 +74,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga4: A generator of values of type `A4`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform : @escaping (A1, A2, A3, A4) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4)>.zip(ga1, ga2, ga3, ga4).map({ t in transform(t.0, t.1, t.2, t.3) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -115,7 +115,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga5: A generator of values of type `A5`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, transform : @escaping (A1, A2, A3, A4, A5) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5)>.zip(ga1, ga2, ga3, ga4, ga5).map({ t in transform(t.0, t.1, t.2, t.3, t.4) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -159,7 +159,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga6: A generator of values of type `A6`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform : @escaping (A1, A2, A3, A4, A5, A6) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6)>.zip(ga1, ga2, ga3, ga4, ga5, ga6).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -206,7 +206,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga7: A generator of values of type `A7`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -256,7 +256,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga8: A generator of values of type `A8`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -309,7 +309,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga9: A generator of values of type `A9`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -365,7 +365,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga10: A generator of values of type `A10`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -424,7 +424,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga11: A generator of values of type `A11`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -486,7 +486,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga12: A generator of values of type `A12`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -551,7 +551,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga13: A generator of values of type `A13`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -619,7 +619,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga14: A generator of values of type `A14`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -690,7 +690,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga15: A generator of values of type `A15`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -764,7 +764,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga16: A generator of values of type `A16`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -841,7 +841,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga17: A generator of values of type `A17`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -921,7 +921,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga18: A generator of values of type `A18`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -1004,7 +1004,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga19: A generator of values of type `A19`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -1090,7 +1090,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga20: A generator of values of type `A20`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -1179,7 +1179,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga21: A generator of values of type `A21`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the
@@ -1271,7 +1271,7 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga22: A generator of values of type `A22`.
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) -> A) -> Gen<A> {
-		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20, t.21) })
+		return Gen<A>.zipWith(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the

--- a/Sources/SwiftCheck/Cartesian.swift
+++ b/Sources/SwiftCheck/Cartesian.swift
@@ -34,7 +34,18 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga1: A generator of values of type `A1`.
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform : @escaping (A1, A2, A3) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3)>.zip(ga1, ga2, ga3).map({ t in transform(t.0, t.1, t.2) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	public static func zipWith<A1, A2, A3>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, transform : @escaping (A1, A2, A3) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3)>.zip(ga1, ga2, ga3).map({ t in transform(t.0, t.1, t.2) })
 	}
 
@@ -61,7 +72,19 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga2: A generator of values of type `A2`.
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform : @escaping (A1, A2, A3, A4) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4)>.zip(ga1, ga2, ga3, ga4).map({ t in transform(t.0, t.1, t.2, t.3) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	public static func zipWith<A1, A2, A3, A4>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, transform : @escaping (A1, A2, A3, A4) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4)>.zip(ga1, ga2, ga3, ga4).map({ t in transform(t.0, t.1, t.2, t.3) })
 	}
 
@@ -90,7 +113,20 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga3: A generator of values of type `A3`.
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, transform : @escaping (A1, A2, A3, A4, A5) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5)>.zip(ga1, ga2, ga3, ga4, ga5).map({ t in transform(t.0, t.1, t.2, t.3, t.4) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	public static func zipWith<A1, A2, A3, A4, A5>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, transform : @escaping (A1, A2, A3, A4, A5) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5)>.zip(ga1, ga2, ga3, ga4, ga5).map({ t in transform(t.0, t.1, t.2, t.3, t.4) })
 	}
 
@@ -121,7 +157,21 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga4: A generator of values of type `A4`.
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform : @escaping (A1, A2, A3, A4, A5, A6) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6)>.zip(ga1, ga2, ga3, ga4, ga5, ga6).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, transform : @escaping (A1, A2, A3, A4, A5, A6) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6)>.zip(ga1, ga2, ga3, ga4, ga5, ga6).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5) })
 	}
 
@@ -154,7 +204,22 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga5: A generator of values of type `A5`.
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6) })
 	}
 
@@ -189,7 +254,23 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga6: A generator of values of type `A6`.
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7) })
 	}
 
@@ -226,7 +307,24 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga7: A generator of values of type `A7`.
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8) })
 	}
 
@@ -265,7 +363,25 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga8: A generator of values of type `A8`.
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9) })
 	}
 
@@ -306,7 +422,26 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga9: A generator of values of type `A9`.
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10) })
 	}
 
@@ -349,7 +484,27 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga10: A generator of values of type `A10`.
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11) })
 	}
 
@@ -394,7 +549,28 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga11: A generator of values of type `A11`.
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12) })
 	}
 
@@ -441,7 +617,29 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga12: A generator of values of type `A12`.
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13) })
 	}
 
@@ -490,7 +688,30 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga13: A generator of values of type `A13`.
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14) })
 	}
 
@@ -541,7 +762,31 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga14: A generator of values of type `A14`.
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15) })
 	}
 
@@ -594,7 +839,32 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga15: A generator of values of type `A15`.
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16) })
 	}
 
@@ -649,7 +919,33 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga16: A generator of values of type `A16`.
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	/// - parameter ga18: A generator of values of type `A18`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17) })
 	}
 
@@ -706,7 +1002,34 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga17: A generator of values of type `A17`.
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	/// - parameter ga18: A generator of values of type `A18`.
+	/// - parameter ga19: A generator of values of type `A19`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18) })
 	}
 
@@ -765,7 +1088,35 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga18: A generator of values of type `A18`.
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	/// - parameter ga18: A generator of values of type `A18`.
+	/// - parameter ga19: A generator of values of type `A19`.
+	/// - parameter ga20: A generator of values of type `A20`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19) })
 	}
 
@@ -826,7 +1177,36 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga19: A generator of values of type `A19`.
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	/// - parameter ga18: A generator of values of type `A18`.
+	/// - parameter ga19: A generator of values of type `A19`.
+	/// - parameter ga20: A generator of values of type `A20`.
+	/// - parameter ga21: A generator of values of type `A21`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20) })
 	}
 
@@ -889,7 +1269,37 @@ extension Gen /*: Cartesian*/ {
 	/// - parameter ga20: A generator of values of type `A20`.
 	/// - parameter ga21: A generator of values of type `A21`.
 	/// - parameter ga22: A generator of values of type `A22`.
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) -> A) -> Gen<A> {
+		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20, t.21) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+	/// - parameter ga1: A generator of values of type `A1`.
+	/// - parameter ga2: A generator of values of type `A2`.
+	/// - parameter ga3: A generator of values of type `A3`.
+	/// - parameter ga4: A generator of values of type `A4`.
+	/// - parameter ga5: A generator of values of type `A5`.
+	/// - parameter ga6: A generator of values of type `A6`.
+	/// - parameter ga7: A generator of values of type `A7`.
+	/// - parameter ga8: A generator of values of type `A8`.
+	/// - parameter ga9: A generator of values of type `A9`.
+	/// - parameter ga10: A generator of values of type `A10`.
+	/// - parameter ga11: A generator of values of type `A11`.
+	/// - parameter ga12: A generator of values of type `A12`.
+	/// - parameter ga13: A generator of values of type `A13`.
+	/// - parameter ga14: A generator of values of type `A14`.
+	/// - parameter ga15: A generator of values of type `A15`.
+	/// - parameter ga16: A generator of values of type `A16`.
+	/// - parameter ga17: A generator of values of type `A17`.
+	/// - parameter ga18: A generator of values of type `A18`.
+	/// - parameter ga19: A generator of values of type `A19`.
+	/// - parameter ga20: A generator of values of type `A20`.
+	/// - parameter ga21: A generator of values of type `A21`.
+	/// - parameter ga22: A generator of values of type `A22`.
+	public static func zipWith<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, _ ga3 : Gen<A3>, _ ga4 : Gen<A4>, _ ga5 : Gen<A5>, _ ga6 : Gen<A6>, _ ga7 : Gen<A7>, _ ga8 : Gen<A8>, _ ga9 : Gen<A9>, _ ga10 : Gen<A10>, _ ga11 : Gen<A11>, _ ga12 : Gen<A12>, _ ga13 : Gen<A13>, _ ga14 : Gen<A14>, _ ga15 : Gen<A15>, _ ga16 : Gen<A16>, _ ga17 : Gen<A17>, _ ga18 : Gen<A18>, _ ga19 : Gen<A19>, _ ga20 : Gen<A20>, _ ga21 : Gen<A21>, _ ga22 : Gen<A22>, transform : @escaping (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22) -> A) -> Gen<A> {
 		return Gen<(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22)>.zip(ga1, ga2, ga3, ga4, ga5, ga6, ga7, ga8, ga9, ga10, ga11, ga12, ga13, ga14, ga15, ga16, ga17, ga18, ga19, ga20, ga21, ga22).map({ t in transform(t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, t.9, t.10, t.11, t.12, t.13, t.14, t.15, t.16, t.17, t.18, t.19, t.20, t.21) })
 	}
 

--- a/Sources/SwiftCheck/Gen.swift
+++ b/Sources/SwiftCheck/Gen.swift
@@ -165,7 +165,7 @@ extension Gen where A : Hashable {
 
 extension Gen {
 	/// Zips together two generators and returns a generator of tuples.
-	public static func zip<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>) -> Gen<(A1, A2)> {
+	public static func zip<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>) -> Gen<(A1, A2)> where A == (A1, A2) {
 		return Gen<(A1, A2)> { r, n in
 			let (r1, r2) = r.split
 			return (ga1.unGen(r1, n), ga2.unGen(r2, n))
@@ -174,8 +174,8 @@ extension Gen {
 
 	/// Returns a new generator that applies a given function to any outputs the
 	/// given generators produce.
-	public static func map<A1, A2, R>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: @escaping (A1, A2) -> R) -> Gen<R> {
-		return zip(ga1, ga2).map({ t in transform(t.0, t.1) })
+	public static func map<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: @escaping (A1, A2) -> A) -> Gen {
+		return Gen<(A1, A2)>.zip(ga1, ga2).map({ t in transform(t.0, t.1) })
 	}
 }
 

--- a/Templates/Cartesian.swift.gyb
+++ b/Templates/Cartesian.swift.gyb
@@ -21,6 +21,8 @@ extension Gen /*: Cartesian*/ {
 # Function definition template
 types_list = ['A{0}'.format(n) for n in range(1, arity + 1)]
 type_parameter_list = ', '.join(types_list)
+previouse_type_parameter_list = ', '.join(['A{0}'.format(n) for n in range(1, arity)])
+latest_type_parameter = 'A{0}'.format(arity)
 parameter_list = ', '.join(['_ ga{0} : Gen<A{0}>'.format(n) for n in range(1, arity + 1)])
 
 # Zip body template
@@ -39,10 +41,10 @@ map_zip_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 1
 % for (t, p) in zip(types_list, ['ga{0}'.format(n) for n in range(1, arity + 1)]):
 	/// - parameter ${p}: A generator of values of type `${t}`.
 % end
-	public static func zip<${type_parameter_list}>(${parameter_list}) -> Gen<(${type_parameter_list})> {
-		return Gen
+	public static func zip<${type_parameter_list}>(${parameter_list}) -> Gen<(${type_parameter_list})> where A == (${type_parameter_list}) {
+		return Gen<((${previouse_type_parameter_list}), ${latest_type_parameter})>
 			.zip(
-				.zip(${previous_zip_arguments}),
+				Gen<(${previouse_type_parameter_list})>.zip(${previous_zip_arguments}),
 				ga${arity}
 			).map { t in
 				(${expanded_previous_tuple}, t.1)
@@ -55,8 +57,8 @@ map_zip_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 1
 % for (t, p) in zip(types_list, ['ga{0}'.format(n) for n in range(1, arity + 1)]):
 	/// - parameter ${p}: A generator of values of type `${t}`.
 % end
-	public static func map<${type_parameter_list}, R>(${parameter_list}, transform : @escaping (${type_parameter_list}) -> R) -> Gen<R> {
-		return zip(${map_zip_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
+	public static func map<${type_parameter_list}>(${parameter_list}, transform : @escaping (${type_parameter_list}) -> A) -> Gen<A> {
+		return Gen<(${type_parameter_list})>.zip(${map_zip_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
 	}
 
 % end

--- a/Templates/Cartesian.swift.gyb
+++ b/Templates/Cartesian.swift.gyb
@@ -33,8 +33,8 @@ expanded_previous_tuple = ', '.join(['t.0.{0}'.format(n - 1) for n in previous_p
 expanded_previous_tuple2 = ', '.join(['t.{0}'.format(n) for n in range(0, arity)])
 
 
-# Map body template
-map_zip_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 1)])
+# ZipWith body template
+zip_with_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 1)])
 }%
 	/// Zips together ${arity} generators into a generator of ${arity}-tuples.
 	///
@@ -57,8 +57,19 @@ map_zip_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 1
 % for (t, p) in zip(types_list, ['ga{0}'.format(n) for n in range(1, arity + 1)]):
 	/// - parameter ${p}: A generator of values of type `${t}`.
 % end
+	@available(*, deprecated, renamed: "zipWith")
 	public static func map<${type_parameter_list}>(${parameter_list}, transform : @escaping (${type_parameter_list}) -> A) -> Gen<A> {
-		return Gen<(${type_parameter_list})>.zip(${map_zip_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
+		return Gen<(${type_parameter_list})>.zip(${zip_with_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
+	}
+
+	/// Returns a new generator that applies a given function to any outputs the
+	/// given generators produce.
+	///
+% for (t, p) in zip(types_list, ['ga{0}'.format(n) for n in range(1, arity + 1)]):
+	/// - parameter ${p}: A generator of values of type `${t}`.
+% end
+	public static func zipWith<${type_parameter_list}>(${parameter_list}, transform : @escaping (${type_parameter_list}) -> A) -> Gen<A> {
+		return Gen<(${type_parameter_list})>.zip(${zip_with_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
 	}
 
 % end

--- a/Templates/Cartesian.swift.gyb
+++ b/Templates/Cartesian.swift.gyb
@@ -59,7 +59,7 @@ zip_with_argument_list = ', '.join(['ga{0}'.format(n) for n in range(1, arity + 
 % end
 	@available(*, deprecated, renamed: "zipWith")
 	public static func map<${type_parameter_list}>(${parameter_list}, transform : @escaping (${type_parameter_list}) -> A) -> Gen<A> {
-		return Gen<(${type_parameter_list})>.zip(${zip_with_argument_list}).map({ t in transform(${expanded_previous_tuple2}) })
+		return Gen<A>.zipWith(${zip_with_argument_list}, transform: transform)
 	}
 
 	/// Returns a new generator that applies a given function to any outputs the

--- a/Templates/CartesianSpec.swift.gyb
+++ b/Templates/CartesianSpec.swift.gyb
@@ -38,16 +38,16 @@ tupled_parameters      = ', '.join(['x{0}'.format(n) for n in range(1, arity + 1
 % end
 	}
 
-	func testGeneratedMaps() {
+	func testGeneratedZipWiths() {
 % for arity in range(3, MAX_ARITY + 1):
 %{
 gen_type_argument_list = ', '.join(['Int' for _ in range(1, arity + 1)])
-map_argument_list      = ', '.join(['Gen.pure({0})'.format(n) for n in range(1, arity + 1)])
+zip_with_argument_list  = ', '.join(['Gen.pure({0})'.format(n) for n in range(1, arity + 1)])
 tupled_parameters      = ', '.join(['x{0}'.format(n) for n in range(1, arity + 1)])
 max_argument_list      = ', '.join(['${0}'.format(n) for n in range(0, arity)])
 }%
 
-		let g${arity} = Gen<Int>.map(${map_argument_list}) { max(${max_argument_list}) }
+		let g${arity} = Gen<Int>.zipWith(${zip_with_argument_list}) { max(${max_argument_list}) }
 
 		property("Gen.zip${arity} behaves") <- forAllNoShrink(g${arity}) { maxInt in
 			maxInt == ${arity}

--- a/Templates/CartesianSpec.swift.gyb
+++ b/Templates/CartesianSpec.swift.gyb
@@ -47,7 +47,7 @@ tupled_parameters      = ', '.join(['x{0}'.format(n) for n in range(1, arity + 1
 max_argument_list      = ', '.join(['${0}'.format(n) for n in range(0, arity)])
 }%
 
-		let g${arity} = Gen<(${gen_type_argument_list})>.map(${map_argument_list}) { max(${max_argument_list}) }
+		let g${arity} = Gen<Int>.map(${map_argument_list}) { max(${max_argument_list}) }
 
 		property("Gen.zip${arity} behaves") <- forAllNoShrink(g${arity}) { maxInt in
 			maxInt == ${arity}

--- a/Tests/SwiftCheckTests/CartesianSpec.swift
+++ b/Tests/SwiftCheckTests/CartesianSpec.swift
@@ -144,121 +144,121 @@ final class CartesianSpec : XCTestCase {
 
 	func testGeneratedMaps() {
 
-		let g3 = Gen<(Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3)) { max($0, $1, $2) }
+		let g3 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3)) { max($0, $1, $2) }
 
 		property("Gen.zip3 behaves") <- forAllNoShrink(g3) { maxInt in
 			maxInt == 3
 		}
 
-		let g4 = Gen<(Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4)) { max($0, $1, $2, $3) }
+		let g4 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4)) { max($0, $1, $2, $3) }
 
 		property("Gen.zip4 behaves") <- forAllNoShrink(g4) { maxInt in
 			maxInt == 4
 		}
 
-		let g5 = Gen<(Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5)) { max($0, $1, $2, $3, $4) }
+		let g5 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5)) { max($0, $1, $2, $3, $4) }
 
 		property("Gen.zip5 behaves") <- forAllNoShrink(g5) { maxInt in
 			maxInt == 5
 		}
 
-		let g6 = Gen<(Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6)) { max($0, $1, $2, $3, $4, $5) }
+		let g6 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6)) { max($0, $1, $2, $3, $4, $5) }
 
 		property("Gen.zip6 behaves") <- forAllNoShrink(g6) { maxInt in
 			maxInt == 6
 		}
 
-		let g7 = Gen<(Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7)) { max($0, $1, $2, $3, $4, $5, $6) }
+		let g7 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7)) { max($0, $1, $2, $3, $4, $5, $6) }
 
 		property("Gen.zip7 behaves") <- forAllNoShrink(g7) { maxInt in
 			maxInt == 7
 		}
 
-		let g8 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8)) { max($0, $1, $2, $3, $4, $5, $6, $7) }
+		let g8 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8)) { max($0, $1, $2, $3, $4, $5, $6, $7) }
 
 		property("Gen.zip8 behaves") <- forAllNoShrink(g8) { maxInt in
 			maxInt == 8
 		}
 
-		let g9 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8) }
+		let g9 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8) }
 
 		property("Gen.zip9 behaves") <- forAllNoShrink(g9) { maxInt in
 			maxInt == 9
 		}
 
-		let g10 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9) }
+		let g10 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9) }
 
 		property("Gen.zip10 behaves") <- forAllNoShrink(g10) { maxInt in
 			maxInt == 10
 		}
 
-		let g11 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) }
+		let g11 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) }
 
 		property("Gen.zip11 behaves") <- forAllNoShrink(g11) { maxInt in
 			maxInt == 11
 		}
 
-		let g12 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) }
+		let g12 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) }
 
 		property("Gen.zip12 behaves") <- forAllNoShrink(g12) { maxInt in
 			maxInt == 12
 		}
 
-		let g13 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) }
+		let g13 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) }
 
 		property("Gen.zip13 behaves") <- forAllNoShrink(g13) { maxInt in
 			maxInt == 13
 		}
 
-		let g14 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) }
+		let g14 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) }
 
 		property("Gen.zip14 behaves") <- forAllNoShrink(g14) { maxInt in
 			maxInt == 14
 		}
 
-		let g15 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) }
+		let g15 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) }
 
 		property("Gen.zip15 behaves") <- forAllNoShrink(g15) { maxInt in
 			maxInt == 15
 		}
 
-		let g16 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) }
+		let g16 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) }
 
 		property("Gen.zip16 behaves") <- forAllNoShrink(g16) { maxInt in
 			maxInt == 16
 		}
 
-		let g17 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) }
+		let g17 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) }
 
 		property("Gen.zip17 behaves") <- forAllNoShrink(g17) { maxInt in
 			maxInt == 17
 		}
 
-		let g18 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) }
+		let g18 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) }
 
 		property("Gen.zip18 behaves") <- forAllNoShrink(g18) { maxInt in
 			maxInt == 18
 		}
 
-		let g19 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) }
+		let g19 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) }
 
 		property("Gen.zip19 behaves") <- forAllNoShrink(g19) { maxInt in
 			maxInt == 19
 		}
 
-		let g20 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) }
+		let g20 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) }
 
 		property("Gen.zip20 behaves") <- forAllNoShrink(g20) { maxInt in
 			maxInt == 20
 		}
 
-		let g21 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) }
+		let g21 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) }
 
 		property("Gen.zip21 behaves") <- forAllNoShrink(g21) { maxInt in
 			maxInt == 21
 		}
 
-		let g22 = Gen<(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21), Gen.pure(22)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) }
+		let g22 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21), Gen.pure(22)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) }
 
 		property("Gen.zip22 behaves") <- forAllNoShrink(g22) { maxInt in
 			maxInt == 22

--- a/Tests/SwiftCheckTests/CartesianSpec.swift
+++ b/Tests/SwiftCheckTests/CartesianSpec.swift
@@ -142,123 +142,123 @@ final class CartesianSpec : XCTestCase {
 		}
 	}
 
-	func testGeneratedMaps() {
+	func testGeneratedZipWiths() {
 
-		let g3 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3)) { max($0, $1, $2) }
+		let g3 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3)) { max($0, $1, $2) }
 
 		property("Gen.zip3 behaves") <- forAllNoShrink(g3) { maxInt in
 			maxInt == 3
 		}
 
-		let g4 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4)) { max($0, $1, $2, $3) }
+		let g4 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4)) { max($0, $1, $2, $3) }
 
 		property("Gen.zip4 behaves") <- forAllNoShrink(g4) { maxInt in
 			maxInt == 4
 		}
 
-		let g5 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5)) { max($0, $1, $2, $3, $4) }
+		let g5 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5)) { max($0, $1, $2, $3, $4) }
 
 		property("Gen.zip5 behaves") <- forAllNoShrink(g5) { maxInt in
 			maxInt == 5
 		}
 
-		let g6 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6)) { max($0, $1, $2, $3, $4, $5) }
+		let g6 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6)) { max($0, $1, $2, $3, $4, $5) }
 
 		property("Gen.zip6 behaves") <- forAllNoShrink(g6) { maxInt in
 			maxInt == 6
 		}
 
-		let g7 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7)) { max($0, $1, $2, $3, $4, $5, $6) }
+		let g7 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7)) { max($0, $1, $2, $3, $4, $5, $6) }
 
 		property("Gen.zip7 behaves") <- forAllNoShrink(g7) { maxInt in
 			maxInt == 7
 		}
 
-		let g8 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8)) { max($0, $1, $2, $3, $4, $5, $6, $7) }
+		let g8 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8)) { max($0, $1, $2, $3, $4, $5, $6, $7) }
 
 		property("Gen.zip8 behaves") <- forAllNoShrink(g8) { maxInt in
 			maxInt == 8
 		}
 
-		let g9 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8) }
+		let g9 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8) }
 
 		property("Gen.zip9 behaves") <- forAllNoShrink(g9) { maxInt in
 			maxInt == 9
 		}
 
-		let g10 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9) }
+		let g10 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9) }
 
 		property("Gen.zip10 behaves") <- forAllNoShrink(g10) { maxInt in
 			maxInt == 10
 		}
 
-		let g11 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) }
+		let g11 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10) }
 
 		property("Gen.zip11 behaves") <- forAllNoShrink(g11) { maxInt in
 			maxInt == 11
 		}
 
-		let g12 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) }
+		let g12 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) }
 
 		property("Gen.zip12 behaves") <- forAllNoShrink(g12) { maxInt in
 			maxInt == 12
 		}
 
-		let g13 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) }
+		let g13 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) }
 
 		property("Gen.zip13 behaves") <- forAllNoShrink(g13) { maxInt in
 			maxInt == 13
 		}
 
-		let g14 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) }
+		let g14 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) }
 
 		property("Gen.zip14 behaves") <- forAllNoShrink(g14) { maxInt in
 			maxInt == 14
 		}
 
-		let g15 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) }
+		let g15 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) }
 
 		property("Gen.zip15 behaves") <- forAllNoShrink(g15) { maxInt in
 			maxInt == 15
 		}
 
-		let g16 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) }
+		let g16 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) }
 
 		property("Gen.zip16 behaves") <- forAllNoShrink(g16) { maxInt in
 			maxInt == 16
 		}
 
-		let g17 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) }
+		let g17 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) }
 
 		property("Gen.zip17 behaves") <- forAllNoShrink(g17) { maxInt in
 			maxInt == 17
 		}
 
-		let g18 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) }
+		let g18 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) }
 
 		property("Gen.zip18 behaves") <- forAllNoShrink(g18) { maxInt in
 			maxInt == 18
 		}
 
-		let g19 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) }
+		let g19 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) }
 
 		property("Gen.zip19 behaves") <- forAllNoShrink(g19) { maxInt in
 			maxInt == 19
 		}
 
-		let g20 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) }
+		let g20 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) }
 
 		property("Gen.zip20 behaves") <- forAllNoShrink(g20) { maxInt in
 			maxInt == 20
 		}
 
-		let g21 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) }
+		let g21 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) }
 
 		property("Gen.zip21 behaves") <- forAllNoShrink(g21) { maxInt in
 			maxInt == 21
 		}
 
-		let g22 = Gen<Int>.map(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21), Gen.pure(22)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) }
+		let g22 = Gen<Int>.zipWith(Gen.pure(1), Gen.pure(2), Gen.pure(3), Gen.pure(4), Gen.pure(5), Gen.pure(6), Gen.pure(7), Gen.pure(8), Gen.pure(9), Gen.pure(10), Gen.pure(11), Gen.pure(12), Gen.pure(13), Gen.pure(14), Gen.pure(15), Gen.pure(16), Gen.pure(17), Gen.pure(18), Gen.pure(19), Gen.pure(20), Gen.pure(21), Gen.pure(22)) { max($0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) }
 
 		property("Gen.zip22 behaves") <- forAllNoShrink(g22) { maxInt in
 			maxInt == 22

--- a/Tests/SwiftCheckTests/GenSpec.swift
+++ b/Tests/SwiftCheckTests/GenSpec.swift
@@ -319,7 +319,7 @@ class GenSpec : XCTestCase {
 			// CHECK-NEXT: *** Passed 100 tests
 			// CHECK-NEXT: .
 			property("Gen.zip8 behaves") <- forAll { (x : Int, y : Int, z : Int, w : Int, a : Int, b : Int, c : Int, d : Int) in
-				let g = Gen<(Int, Int, Int, Int, Int, Int)>.zip(Gen.pure(x), Gen.pure(y), Gen.pure(z), Gen.pure(w), Gen.pure(a), Gen.pure(b), Gen.pure(c), Gen.pure(d))
+				let g = Gen<(Int, Int, Int, Int, Int, Int, Int, Int)>.zip(Gen.pure(x), Gen.pure(y), Gen.pure(z), Gen.pure(w), Gen.pure(a), Gen.pure(b), Gen.pure(c), Gen.pure(d))
 				return forAllNoShrink(g) { (t) in
 					return (t.0, t.1, t.2, t.3, t.4, t.5) == (x, y, z, w, a, b)
 						&& (t.6, t.7) == (c, d)

--- a/Tests/SwiftCheckTests/SimpleSpec.swift
+++ b/Tests/SwiftCheckTests/SimpleSpec.swift
@@ -108,7 +108,7 @@ extension ArbitraryLargeFoo : Arbitrary {
 				return Gen<(Int8, Int16, Int32, Int64
 					, UInt8, UInt16, UInt32, UInt64
 					, Int , UInt, Bool, (Bool, Bool), (Bool, Bool, Bool), (Bool, Bool, Bool, Bool))>
-					.map(
+					.zipWith(
 						Bool.arbitrary,
 						Gen<(Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary),
 						Gen<(Bool, Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary, Bool.arbitrary),

--- a/Tests/SwiftCheckTests/SimpleSpec.swift
+++ b/Tests/SwiftCheckTests/SimpleSpec.swift
@@ -105,7 +105,9 @@ extension ArbitraryLargeFoo : Arbitrary {
 				, UInt8.arbitrary, UInt16.arbitrary, UInt32.arbitrary, UInt64.arbitrary
 				, Int.arbitrary, UInt.arbitrary)
 			.flatMap { t in
-				return Gen<(Bool, (Bool, Bool), (Bool, Bool, Bool), (Bool, Bool, Bool, Bool))>
+				return Gen<(Int8, Int16, Int32, Int64
+					, UInt8, UInt16, UInt32, UInt64
+					, Int , UInt, Bool, (Bool, Bool), (Bool, Bool, Bool), (Bool, Bool, Bool, Bool))>
 					.map(
 						Bool.arbitrary,
 						Gen<(Bool, Bool)>.zip(Bool.arbitrary, Bool.arbitrary),


### PR DESCRIPTION
What's in this pull request?
============================

This change does for `zip` what #250 did to `fromElements`, i.e. forces type equality between the `Gen` type and the generic static zip variant.

Why merge this pull request?
============================

This fixes the following issues with `zip`:

- `let gen = Gen<Int>.zip(Gen.pure(1), Gen.pure(2))` compiles but unexpectedly returns `Gen<(Int, Int)>`. This will not compile after applying these changes
- `let z = Gen.zip(Gen.pure(1), Gen.pure(2))` did not compile (`Generic parameter 'A' could not be inferred). This will now compile.

This also removes the generic return type from `Gen.map`, instead `map` now always returns `Gen<A>`.

What's worth discussing about this pull request?
================================================

Using `zip` within `Gen` is now a bit more verbose, e.g. `let x = zip(...)` now needs to be `let x = Gen<...>.zip(...)`.

I haven't written any `gyb` before, please let me know if I can improve anything.

What downsides are there to merging this pull request?
======================================================

This is a breaking change and some code might not compile anymore.
