### PR TITLE
Pin FileCheck To A Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
 			targets: ["SwiftCheck"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/trill-lang/FileCheck.git", .branch("master"))
+		.package(url: "https://github.com/trill-lang/FileCheck.git", from: "0.0.3")
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
I'm informed that SwiftPM's dependency resolution is not a fan of projects with transitive dependencies that both depend on top-of-tree projects.  Experiment with pinning to a minimum version of FileCheck to see if we can't work that out.