### PR TITLE
Fix printing passing counter-countexamples in verbose mode

### DIFF
--- a/Sources/SwiftCheck/Check.swift
+++ b/Sources/SwiftCheck/Check.swift
@@ -227,7 +227,9 @@ infix operator ==== : ComparisonPrecedence
 public func ==== <A>(x : A, y : A) -> Property
 	where A : Equatable
 {
-	return (x == y).counterexample(String(describing: x) + " /= " + String(describing: y))
+	let isEq = (x == y)
+	let text = isEq ? "==" : "!="
+	return isEq.counterexample("\(x) \(text) \(y)")
 }
 
 precedencegroup SwiftCheckLabelPrecedence {

--- a/Tests/SwiftCheckTests/SimpleSpec.swift
+++ b/Tests/SwiftCheckTests/SimpleSpec.swift
@@ -232,6 +232,22 @@ class SimpleSpec : XCTestCase {
 			) { a, b in
 				return a != b
 			}
+
+			// CHECK: Passed: (.)
+			// CHECK-NEXT: 0
+			// CHECK-NEXT: 0 == 0
+			// CHECK: Passed: (.)
+			// CHECK-NEXT: {{[0-9]+}}
+			// CHECK-NEXT: {{[0-9]+}} == {{[0-9]+}}
+			// CHECK: Passed: (.)
+			// CHECK-NEXT: {{[0-9]+}}
+			// CHECK-NEXT: {{[0-9]+}} == {{[0-9]+}}
+			// CHECK: *** Passed 3 tests
+			// CHECK-NEXT: .
+			let verboseLimit = CheckerArguments(maxAllowableSuccessfulTests: 3)
+			property("Passing counter-counterexamples print correctly", arguments: verboseLimit) <- forAll { (x : Int) in
+				return x*x ==== x*x
+			}.verbose
 		})
 	}
 


### PR DESCRIPTION
What's in this pull request?
============================

Passing counter-counterexamples can become visible in verbose output but `counterexample` always assumed its output would only be shown while printing a failing test.  Make it so verbose output reflects what actually happened while processing an example value.