### PR TITLE
Provide non-DSL spellings of primitives

### DIFF
--- a/Sources/SwiftCheck/Check.swift
+++ b/Sources/SwiftCheck/Check.swift
@@ -194,6 +194,91 @@ public func <- (checker : ReportiveQuickCheck, test : @autoclosure @escaping () 
 	_ = quickCheckWithResult(checker.args, test())
 }
 
+/// Tests a property and prints the results to stdout.
+///
+/// - parameter prop: The property to be tested.
+/// - parameter name: The name of the property being tested.
+@available(*, deprecated, message: "Use quickCheck(asserting:) or quickCheck(reporting:) instead.")
+public func quickCheck(_ prop : Testable, name : String = "") {
+	_ = quickCheckWithResult(CheckerArguments(name: name), prop)
+}
+
+/// The interface for properties to be run through SwiftCheck with an XCTest
+/// assert.  The property will still generate console output during testing.
+///
+/// - Parameters:
+///   - message: A description of the property.
+///   - arguments: An optional set of arguments to tune the test runner.
+///   - file: The file in which test occurred. Defaults to the file name of the
+///     test case in which this function was called.
+///   - line: The line number on which test occurred. Defaults to the line
+///     number on which this function was called.
+///   - prop: A block that carries the property or invariant to be tested.
+public func quickCheck(
+	asserting message: String, arguments: CheckerArguments? = nil,
+	file : StaticString = #file, line : UInt = #line,
+	property prop : @autoclosure @escaping () -> Testable
+) {
+	property(message, arguments: arguments, file: file, line: line) <- prop
+}
+
+/// The interface for properties to be run through SwiftCheck with an XCTest
+/// assert.  The property will still generate console output during testing.
+///
+/// - Parameters:
+///   - message: A description of the property.
+///   - arguments: An optional set of arguments to tune the test runner.
+///   - file: The file in which test occurred. Defaults to the file name of the
+///     test case in which this function was called.
+///   - line: The line number on which test occurred. Defaults to the line
+///     number on which this function was called.
+///   - prop: A block that carries the property or invariant to be tested.
+public func quickCheck(
+	asserting message: String, arguments: CheckerArguments? = nil,
+	file : StaticString = #file, line : UInt = #line,
+	property prop : () -> Testable
+) {
+	property(message, arguments: arguments, file: file, line: line) <- prop
+}
+
+/// The interface for properties to be run through SwiftCheck without an XCTest
+/// assert.  The property will still generate console output during testing.
+///
+/// - Parameters:
+///   - message: A description of the property.
+///   - arguments: An optional set of arguments to tune the test runner.
+///   - file: The file in which test occurred. Defaults to the file name of the
+///     test case in which this function was called.
+///   - line: The line number on which test occurred. Defaults to the line
+///     number on which this function was called.
+///   - prop: A block that carries the property or invariant to be tested.
+public func quickCheck(
+	reporting message: String, arguments: CheckerArguments? = nil,
+	file : StaticString = #file, line : UInt = #line,
+	property prop : @autoclosure @escaping () -> Testable
+) {
+	reportProperty(message, arguments: arguments, file: file, line: line) <- prop
+}
+
+/// The interface for properties to be run through SwiftCheck without an XCTest
+/// assert.  The property will still generate console output during testing.
+///
+/// - Parameters:
+///   - message: A description of the property.
+///   - arguments: An optional set of arguments to tune the test runner.
+///   - file: The file in which test occurred. Defaults to the file name of the
+///     test case in which this function was called.
+///   - line: The line number on which test occurred. Defaults to the line
+///     number on which this function was called.
+///   - prop: A block that carries the property or invariant to be tested.
+public func quickCheck(
+	reporting message: String, arguments: CheckerArguments? = nil,
+	file : StaticString = #file, line : UInt = #line,
+	property prop : () -> Testable
+) {
+	reportProperty(message, arguments: arguments, file: file, line: line) <- prop
+}
+
 precedencegroup SwiftCheckImplicationPrecedence {
 	associativity: right
 	lowerThan: ComparisonPrecedence

--- a/Sources/SwiftCheck/Test.swift
+++ b/Sources/SwiftCheck/Test.swift
@@ -533,14 +533,6 @@ public func exists<A : Arbitrary>(_ gen : Gen<A>, pf : @escaping (A) throws -> T
 	}
 }
 
-/// Tests a property and prints the results to stdout.
-///
-/// - parameter prop: The property to be tested.
-/// - parameter name: The name of the property being tested.
-public func quickCheck(_ prop : Testable, name : String = "") {
-	_ = quickCheckWithResult(CheckerArguments(name: name), prop)
-}
-
 // MARK: - Implementation Details
 
 internal enum Result {


### PR DESCRIPTION
What's in this pull request?
============================

#261 requests a way to spell the testing primitives without using the DSL. 

What's worth discussing about this pull request?
================================================

Operators in Swift have a complex and storied history, and their use outside of the standard library is the subject of a lot of styling debates.  Many frameworks that choose to provide custom operators do so because they are trying to mimic a particular syntax or structure.  The trap many fall into is not providing a way out of the DSL.

What downsides are there to merging this pull request?
======================================================

On the other hand, SwiftCheck's DSL isn't just a matter of syntax.  Tests are data in this framework, and can be [stored and computed with](https://github.com/typelift/SwiftCheck/blob/master/Tests/SwiftCheckTests/FailureSpec.swift#L27).  `<-` indicates when you want to statement-ize that data and execute the test.  Providing an out dilutes that philosophy.