### PR TITLE
Fix Tutorial playground for removal of `ArrayOf<>`

### DIFF
--- a/Tutorial.playground/Contents.swift
+++ b/Tutorial.playground/Contents.swift
@@ -342,7 +342,7 @@ property("The reverse of the reverse of an array is that array") <- forAll { (xs
 //                                           v             v
 property("filter behaves") <- forAll { (xs : [Int], pred : ArrowOf<Int, Bool>) in
 	let f = pred.getArrow
-	return xs.getArray.filter(f).reduce(true, { $0 && f($1) })
+	return xs.filter(f).reduce(true, { $0 && f($1) })
 	// ^ This property says that if we filter an array then apply the predicate
 	//   to all its elements, then they should all respond with `true`.
 }


### PR DESCRIPTION
What's in this pull request?
============================

This case was changed from `ArrayOf<Int>` to `[Int]`, but the corresponding `getArray` stuck around.

From #264, on this line https://github.com/CodaFi/SwiftCheck/commit/b6b4bc61dc0a41889040a38ebe8f5926ae713d2c#diff-47970fd31917fb63ccf81bd68065f0abR343

Thanks for the hard work on this!

Why merge this pull request?
============================

Tutorial fails to run without it:
```
error: Tutorial.playground:339:9: error: value of type '[Int]' has no member 'getArray'
        return xs.getArray.filter(f).reduce(true, { $0 && f($1) })
               ^~ ~~~~~~~~
```

What's worth discussing about this pull request?
================================================

N/A

What downsides are there to merging this pull request?
======================================================

N/A
