### PR TITLE
Fix vary function

### DIFF
--- a/Sources/SwiftCheck/Gen.swift
+++ b/Sources/SwiftCheck/Gen.swift
@@ -415,7 +415,7 @@ private func delay<A>() -> Gen<(Gen<A>) -> A> {
 private func vary<S : BinaryInteger>(_ k : S, _ rng : StdGen) -> StdGen {
 	let s = rng.split
 	let gen = ((k % 2) == 0) ? s.0 : s.1
-	return (k == (k / 2)) ? gen : vary(k / 2, rng)
+	return (k == (k / 2)) ? gen : vary(k / 2, gen)
 }
 
 private func size(_ k : Int, _ m : Int) -> Int {


### PR DESCRIPTION
What's in this pull request?
============================

This commit fixes a bug where `vary(k, rng)` always returns `rng.split.0` which in turn led to `Gen.variant(seed)` ignoring the `seed` argument.


Why merge this pull request?
============================

It fixes a bug.

What's worth discussing about this pull request?
================================================

I haven't written any tests for the changes since it's in a private function. Let me know if you want me to write tests for `Gen.variant` instead.

What downsides are there to merging this pull request?
======================================================

None that I can think of.