### PR TITLE
Rename static map to zipWith

### DIFF
--- a/Sources/SwiftCheck/Gen.swift
+++ b/Sources/SwiftCheck/Gen.swift
@@ -172,9 +172,13 @@ extension Gen {
 		}
 	}
 
+	@available(*, deprecated, renamed: "zipWith")
+	public static func map<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: @escaping (A1, A2) -> A) -> Gen {
+		return Gen.zipWith(ga1, ga2, transform: transform)
+	}
 	/// Returns a new generator that applies a given function to any outputs the
 	/// given generators produce.
-	public static func map<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: @escaping (A1, A2) -> A) -> Gen {
+	public static func zipWith<A1, A2>(_ ga1 : Gen<A1>, _ ga2 : Gen<A2>, transform: @escaping (A1, A2) -> A) -> Gen {
 		return Gen<(A1, A2)>.zip(ga1, ga2).map({ t in transform(t.0, t.1) })
 	}
 }


### PR DESCRIPTION
What's in this pull request?
============================

Deprecates the static `map` function for two generator arguments and renames it to `zipWith`.
This was overlooked in d0ac3b949c0f63f05e9de84d91b4424c510c7b7b.

I've noticed that this repository hasn't seen any activity for 3 months. I'd be happy to help in any way I can.