### PR TITLE
Updated references to `one(of:)` in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ property("Shrunken lists of integers always contain [] or [0]") <- forAll { (l :
 Properties can even depend on other properties:
 
 ```swift
-property("Gen.oneOf multiple generators picks only given generators") <- forAll { (n1 : Int, n2 : Int) in
+property("Gen.one(of:) multiple generators picks only given generators") <- forAll { (n1 : Int, n2 : Int) in
     let g1 = Gen.pure(n1)
     let g2 = Gen.pure(n2)
     // Here we give `forAll` an explicit generator.  Before SwiftCheck was using
     // the types of variables involved in the property to create an implicit
     // Generator behind the scenes.
-    return forAll(Gen.oneOf([g1, g2])) { $0 == n1 || $0 == n2 }
+    return forAll(Gen.one(of: [g1, g2])) { $0 == n1 || $0 == n2 }
 }
 ```
 

--- a/Sources/SwiftCheck/Gen.swift
+++ b/Sources/SwiftCheck/Gen.swift
@@ -69,7 +69,7 @@ public struct Gen<A> {
 	public static func one<S : BidirectionalCollection>(of gs : S) -> Gen<A>
 		where S.Iterator.Element == Gen<A>, S.Index : RandomType
 	{
-		assert(gs.count != 0, "oneOf used with empty list")
+		assert(gs.count != 0, "one(of:) used with empty list")
 
 		return Gen<S.Index>.choose((gs.startIndex, gs.index(before: gs.endIndex))).flatMap { x in
 			return gs[x]
@@ -81,7 +81,7 @@ public struct Gen<A> {
 	///
 	/// Only use this function when you need to assign uneven "weights" to each
 	/// generator.  If all generators need to have an equal chance of being
-	/// selected, use `Gen.oneOf`.
+	/// selected, use `Gen.one(of:)`.
 	public static func frequency<S : Sequence>(_ xs : S) -> Gen<A>
 		where S.Iterator.Element == (Int, Gen<A>)
 	{


### PR DESCRIPTION
What's in this pull request?
============================

Updated references to `one(of:)` that used to be `oneOf`.

Why merge this pull request?
============================

Keep the documentation up to date.
