### PR TITLE
Updated references to `reverse` in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ property("The reverse of the reverse of an array is that array") <- forAll { (xs
     // *** Passed 100 tests
     // (100% , Right identity, Left identity)
     return
-        (xs.reverse().reverse() == xs) <?> "Left identity"
+        (xs.reversed().reversed() == xs) <?> "Left identity"
         ^&&^
-        (xs == xs.reverse().reverse()) <?> "Right identity"
+        (xs == xs.reversed().reversed()) <?> "Right identity"
 }
 ```
 

--- a/Sources/SwiftCheck/Test.swift
+++ b/Sources/SwiftCheck/Test.swift
@@ -83,9 +83,9 @@
 ///     v                                                                v
 ///     property("The reverse of the reverse of an array is that array") <- forAll { (xs : [Int]) in
 ///            return
-///                (xs.reverse().reverse() == xs) <?> "Reverse on the left"
+///                (xs.reversed().reversed() == xs) <?> "Reverse on the left"
 ///             ^&&^
-///                 (xs == xs.reverse().reverse()) <?> "Reverse on the right"
+///                 (xs == xs.reversed().reversed()) <?> "Reverse on the right"
 ///     }
 ///
 /// Why require types?  For one, Swift cannot infer the types of local variables


### PR DESCRIPTION
Thank you for the useful library!

What's in this pull request?
============================
replace `reverse` to `reversed` to fix compile error when referreing to readme

Why merge this pull request?
============================
Keep the documentation up to date.
