### PR TITLE
Update swift tools version to 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 
 import PackageDescription
 


### PR DESCRIPTION
What's in this pull request?
============================
This updates swift tools version to 5.2.

Why merge this pull request?
============================
This fixes #296. Without this fix, Xcode (from 11.4 and above) will resolve all the test dependencies of SwiftCheck as well: FileCheck.
This prevents Xcode from building previews for SwiftUI, essentially making SwiftUI unusable.

Swift Packages section of [release note for Xcode 11.4](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_release_notes):
> Remote Swift packages with tools version 5.2 and above no longer resolve package dependencies that are only used in their test targets, improving performance and reducing the chance of dependency version conflicts. (56925017)

What's worth discussing about this pull request?
================================================
N/A

What downsides are there to merging this pull request?
======================================================
N/A