### PR TITLE
Adds ability to generate arbitrary `Date`s and `UUID`s

### DIFF
--- a/SwiftCheck.xcodeproj/project.pbxproj
+++ b/SwiftCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02135F9324AA3BB300E33BF1 /* ArbitrarySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02135F9224AA3BA800E33BF1 /* ArbitrarySpec.swift */; };
+		02135F9424AA3BB300E33BF1 /* ArbitrarySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02135F9224AA3BA800E33BF1 /* ArbitrarySpec.swift */; };
+		02135F9524AA3BB400E33BF1 /* ArbitrarySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02135F9224AA3BA800E33BF1 /* ArbitrarySpec.swift */; };
 		6A761B9E1F14E92100A7D74F /* Arbitrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A761B771F14E91400A7D74F /* Arbitrary.swift */; };
 		6A761B9F1F14E92100A7D74F /* Cartesian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A761B781F14E91400A7D74F /* Cartesian.swift */; };
 		6A761BA01F14E92100A7D74F /* Check.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A761B791F14E91400A7D74F /* Check.swift */; };
@@ -176,6 +179,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02135F9224AA3BA800E33BF1 /* ArbitrarySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArbitrarySpec.swift; sourceTree = "<group>"; };
 		6A761B751F14E91400A7D74F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6A761B771F14E91400A7D74F /* Arbitrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Arbitrary.swift; sourceTree = "<group>"; };
 		6A761B781F14E91400A7D74F /* Cartesian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cartesian.swift; sourceTree = "<group>"; };
@@ -328,6 +332,7 @@
 		6A761B8C1F14E91500A7D74F /* SwiftCheckTests */ = {
 			isa = PBXGroup;
 			children = (
+				02135F9224AA3BA800E33BF1 /* ArbitrarySpec.swift */,
 				6A761B8D1F14E91500A7D74F /* BooleanIdentitySpec.swift */,
 				6A761B8E1F14E91500A7D74F /* CartesianSpec.swift */,
 				6A761B8F1F14E91500A7D74F /* ComplexSpec.swift */,
@@ -676,6 +681,7 @@
 				8235D34C1F72DD0B00207FA1 /* Diagnostics.swift in Sources */,
 				8235D34D1F72DD0B00207FA1 /* EditDistance.swift in Sources */,
 				8235D34E1F72DD0B00207FA1 /* FileCheck.swift in Sources */,
+				02135F9524AA3BB400E33BF1 /* ArbitrarySpec.swift in Sources */,
 				8235D34F1F72DD0B00207FA1 /* Pattern.swift in Sources */,
 				6A761C021F14E93B00A7D74F /* SimpleSpec.swift in Sources */,
 				6A761C031F14E93B00A7D74F /* TestSpec.swift in Sources */,
@@ -727,6 +733,7 @@
 				8235D3561F72DD2200207FA1 /* CheckString.swift in Sources */,
 				8235D3571F72DD2200207FA1 /* ColoredStream.swift in Sources */,
 				8235D3581F72DD2200207FA1 /* Diagnostics.swift in Sources */,
+				02135F9324AA3BB300E33BF1 /* ArbitrarySpec.swift in Sources */,
 				8235D3591F72DD2200207FA1 /* EditDistance.swift in Sources */,
 				8235D35A1F72DD2200207FA1 /* FileCheck.swift in Sources */,
 				8235D35B1F72DD2200207FA1 /* Pattern.swift in Sources */,
@@ -778,6 +785,7 @@
 				8235D3501F72DD1B00207FA1 /* CheckString.swift in Sources */,
 				8235D3511F72DD1B00207FA1 /* ColoredStream.swift in Sources */,
 				8235D3521F72DD1B00207FA1 /* Diagnostics.swift in Sources */,
+				02135F9424AA3BB300E33BF1 /* ArbitrarySpec.swift in Sources */,
 				8235D3531F72DD1B00207FA1 /* EditDistance.swift in Sources */,
 				8235D3541F72DD1B00207FA1 /* FileCheck.swift in Sources */,
 				8235D3551F72DD1B00207FA1 /* Pattern.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,6 +12,7 @@ import XCTest
 
 #if !os(macOS)
 XCTMain([
+	ArbitrarySpec.allTests,
 	BooleanIdentitySpec.allTests,
 	ComplexSpec.allTests,
 	DiscardSpec.allTests,

--- a/Tests/SwiftCheckTests/ArbitrarySpec.swift
+++ b/Tests/SwiftCheckTests/ArbitrarySpec.swift
@@ -1,0 +1,28 @@
+import SwiftCheck
+import XCTest
+import Foundation
+#if SWIFT_PACKAGE
+import FileCheck
+#endif
+
+class ArbitrarySpec : XCTestCase {
+	func testAll() {
+		XCTAssert(fileCheckOutput {
+			// CHECK: *** Passed 100 tests
+			// CHECK-NEXT: .
+			property("generates arbitrary `Date`s") <- forAll { (_ : Date) in
+				// The fact that we can return something here means that
+				// generating the Date succeeded
+				return true
+			}
+
+			// CHECK: *** Passed 100 tests
+			// CHECK-NEXT: .
+			property("generates arbitrary `UUID`s") <- forAll { (_ : UUID) in
+				// The fact that we can return something here means that
+				// generating the UUID succeeded
+				return true
+			}
+		})
+	}
+}


### PR DESCRIPTION
What's in this pull request?
============================

I added definitions of `arbitrary` for the `Date` and `UUID` foundation types. I also included unit tests for both.

Why merge this pull request?
============================

I believe these two generators are useful to may people, and especially the UUID generator is not trivial as it required me to study RFC 4122 and implement the UUID v4 spec.

What's worth discussing about this pull request?
================================================

* I created a new test file for this. Not sure if that's what you want, or if you prefer to put it somewhere else.
* I also included two `Data` utility functions for hex encoding. Those are also highly generic but not easy to find currently. Not sure if that's a problem or not.

What downsides are there to merging this pull request?
======================================================

None that I can think of.
