### PR TITLE
Fix usages in README and doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ public static var arbitrary : Gen<MyClass> {
             a: c.generate(),
 
             // or pass a custom generator
-            b: c.generate(Bool.suchThat { $0 == false }),
+            b: c.generate(using: Bool.arbitrary.suchThat { $0 == false }),
 
             // .. and so on, for as many values and types as you need.
             c: c.generate(), ...

--- a/Sources/SwiftCheck/Compose.swift
+++ b/Sources/SwiftCheck/Compose.swift
@@ -22,7 +22,7 @@ extension Gen {
 	///                 a: c.generate(),
 	///
 	///                 // or pass a custom generator
-	///                 b: c.generate(Bool.arbitrary.suchThat { $0 == false }),
+	///                 b: c.generate(using: Bool.arbitrary.suchThat { $0 == false }),
 	///
 	///                 // ... and so on, for as many values & types as you need
 	///                 c: c.generate(), ...


### PR DESCRIPTION
What's in this pull request?
============================

Fixes a usage shown in README: `Bool.suchThat` is mentioned, but it doesn't exist.


Why merge this pull request?
============================

It makes the documentation a bit more c/p friendly.


What's worth discussing about this pull request?
================================================

:man_shrugging: 

What downsides are there to merging this pull request?
======================================================

:man_shrugging: 
