### PR TITLE
Fix Swift 6 Concurrency Errors

### DIFF
--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Sources/SwiftCheck/Random.swift
+++ b/Sources/SwiftCheck/Random.swift
@@ -100,12 +100,15 @@ extension StdGen : Equatable, CustomStringConvertible {
 	}
 }
 
-private var theStdGen : StdGen = mkStdRNG(0)
+private actor TheStdGen {
+    static var shared : StdGen = mkStdRNG(0)
+
+}
 
 /// A library-provided standard random number generator.
 public func newStdGen() -> StdGen {
-	let (left, right) = theStdGen.split
-	theStdGen = left
+    let (left, right) = TheStdGen.shared.split
+    TheStdGen.shared = left
 	return right
 }
 

--- a/Tests/SwiftCheckTests/ComplexSpec.swift
+++ b/Tests/SwiftCheckTests/ComplexSpec.swift
@@ -12,16 +12,16 @@ import XCTest
 import FileCheck
 #endif
 
-let upper : Gen<Character> = Gen<Character>.fromElements(in: "A"..."Z")
-let lower : Gen<Character> = Gen<Character>.fromElements(in: "a"..."z")
-let numeric : Gen<Character> = Gen<Character>.fromElements(in: "0"..."9")
-let special : Gen<Character> = Gen<Character>.fromElements(of: ["!", "#", "$", "%", "&", "'", "*", "+", "-", "/", "=", "?", "^", "_", "`", "{", "|", "}", "~", "."])
-let hexDigits = Gen<Character>.one(of: [
-	Gen<Character>.fromElements(in: "A"..."F"),
-	numeric,
-])
 
 class ComplexSpec : XCTestCase {
+    let upper : Gen<Character> = Gen<Character>.fromElements(in: "A"..."Z")
+    let lower : Gen<Character> = Gen<Character>.fromElements(in: "a"..."z")
+    let numeric : Gen<Character> = Gen<Character>.fromElements(in: "0"..."9")
+    let special : Gen<Character> = Gen<Character>.fromElements(of: ["!", "#", "$", "%", "&", "'", "*", "+", "-", "/", "=", "?", "^", "_", "`", "{", "|", "}", "~", "."])
+    lazy var hexDigits = Gen<Character>.one(of: [
+        Gen<Character>.fromElements(in: "A"..."F"),
+        numeric,
+    ])
 	func testEmailAddressProperties() {
 		XCTAssert(fileCheckOutput(withPrefixes: ["CHECKEMAIL"]) {
 			let localEmail = Gen<Character>.one(of: [

--- a/Tests/SwiftCheckTests/SimpleSpec.swift
+++ b/Tests/SwiftCheckTests/SimpleSpec.swift
@@ -120,28 +120,28 @@ extension ArbitraryLargeFoo : Arbitrary {
 	}
 }
 
-let composedArbitraryLargeFoo = Gen<ArbitraryLargeFoo>.compose { c in
-	let evenInt16 = Int16.arbitrary.suchThat { $0 % 2 == 0 }
-	return ArbitraryLargeFoo(
-		a: c.generate(),
-		b: c.generate(using: evenInt16),
-		c: c.generate(),
-		d: c.generate(),
-		e: c.generate(),
-		f: c.generate(),
-		g: c.generate(),
-		h: c.generate(),
-		i: c.generate(),
-		j: c.generate(),
-		k: c.generate(),
-		l: (c.generate(), c.generate()),
-		m: (c.generate(), c.generate(), c.generate()),
-		n: (c.generate(), c.generate(), c.generate(), c.generate())
-	)
-}
-
 class SimpleSpec : XCTestCase {
 	func testAll() {
+        let composedArbitraryLargeFoo = Gen<ArbitraryLargeFoo>.compose { c in
+            let evenInt16 = Int16.arbitrary.suchThat { $0 % 2 == 0 }
+            return ArbitraryLargeFoo(
+                a: c.generate(),
+                b: c.generate(using: evenInt16),
+                c: c.generate(),
+                d: c.generate(),
+                e: c.generate(),
+                f: c.generate(),
+                g: c.generate(),
+                h: c.generate(),
+                i: c.generate(),
+                j: c.generate(),
+                k: c.generate(),
+                l: (c.generate(), c.generate()),
+                m: (c.generate(), c.generate(), c.generate()),
+                n: (c.generate(), c.generate(), c.generate(), c.generate())
+            )
+        }
+        
 		XCTAssert(fileCheckOutput {
 			// CHECK: *** Passed 100 tests
 			// CHECK-NEXT: .


### PR DESCRIPTION
What's in this pull request?
============================

This PR adds compatibility with Swift 6 mode while maintaining Swift 5.2 compatibility.
- Makes SwiftCheck compatible with Swift 6 language
- Fix Swift 6 concurrency errors.

Why merge this pull request?
============================

This updates increases concurrency safety and lays the foundation for further updates, such as adding compatibility with the Swift Testing (swift-testing) framework.

What's worth discussing about this pull request?
================================================

Not too much I think. Seems like an uncontroversial change to me, but I'm happy to discuss. 

What downsides are there to merging this pull request?
======================================================

None that I'm aware of.
